### PR TITLE
Add workflows for test, build and publish

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,27 @@
+name: Publish release image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish-image:
+    runs-on: ubuntu-latest
+    name: Publish container image
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set image env
+        # Refer https://stackoverflow.com/a/58178121 for git tag extraction.
+        run: echo ::set-env name=IMG::storageos/api-manager:${GITHUB_REF#refs/*/}
+      - name: Login to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build container image
+        run: make docker-build
+      - name: Push container image
+        run: make docker-push

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,38 @@
+name: Test and build image
+
+on: [push, pull_request]
+
+env:
+  IMG: storageos/api-manager:develop
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15.2'
+      - name: go-test
+        run: make test
+
+  build-image:
+    needs: test
+    runs-on: ubuntu-latest
+    name: Build container image
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build container image
+        run: make docker-build
+      - name: Login to container registry
+        if: ${{ github.ref == 'ref/head/master' }}
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Push container image
+        if: ${{ github.ref == 'ref/head/master' }}
+        run: make docker-push

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # StorageOS API Manager
 
+[![Test and build image](https://github.com/storageos/api-manager/workflows/Test%20and%20build%20image/badge.svg)](https://github.com/storageos/api-manager/actions?query=workflow%3A%22Test+and+build+image%22)
+
 The StorageOS API Manager acts as a middle-man between various APIs.  It has all
 the capabilites of a Kubernetes Operator and is also able to communicate with
 the StorageOS control plane API.


### PR DESCRIPTION
- Add kubebuilder make target to install kubebuilder tools. This is required for running envtest.
- Add workflow to run tests and image builds on every push and PR. A `develop` image will be published after every merge.
- Add workflow to publishing release images for "v" prefixed tags.