### PR TITLE
Fix develop image workflow typo

### DIFF
--- a/.github/workflows/develop-image.yml
+++ b/.github/workflows/develop-image.yml
@@ -2,7 +2,7 @@ name: Publish develop image
 
 on:
   push:
-    branch:
+    branches:
       - master
 
 env:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2.2.0
+        with:
+          args: --timeout=5m
 
   test-build:
     name: Run tests and build


### PR DESCRIPTION
Must be `on.push.branches`

Refer: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags

This was causing the workflow to be triggered for all the branches.

Also,  add timeout for golangci-lint to avoid first run on a new branch failure.