### PR TITLE
Use PV name as service name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/go-logr/logr v0.1.0
 	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/onsi/ginkgo v1.12.0

--- a/internal/controllers/sharedvolume/README.md
+++ b/internal/controllers/sharedvolume/README.md
@@ -29,6 +29,7 @@ tunable via the `-api-poll-interval` flag.
 Only volumes that have all of the follwing will be considered:
 
 - `nfs.serviceEndpoint` set to a valid `<ip>:<port>`.
+- `csi.storage.k8s.io/pv/name` label set.
 - `csi.storage.k8s.io/pvc/name` label set.
 - `csi.storage.k8s.io/pvc/namespace` label set.
 - PVC matching labels above.

--- a/internal/controllers/sharedvolume/controller_test.go
+++ b/internal/controllers/sharedvolume/controller_test.go
@@ -69,16 +69,17 @@ func TestReconcile(t *testing.T) {
 			name: "New volume",
 			volumes: []*storageos.SharedVolume{
 				{
-					ID:        "1234",
-					Name:      "foo",
-					Namespace: "bar",
+					ID:          "1234",
+					ServiceName: "baz-service",
+					PVCName:     "foo",
+					Namespace:   "bar",
 				},
 			},
 			pvcs: []runtime.Object{fooPVC},
 			wantServices: []corev1.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
+						Name:      "baz-service",
 						Namespace: "bar",
 						Labels: map[string]string{
 							"storageos.com/sharedvolume": "1234",
@@ -109,7 +110,8 @@ func TestReconcile(t *testing.T) {
 			wantCached: []*storageos.SharedVolume{
 				{
 					ID:               "1234",
-					Name:             "foo",
+					ServiceName:      "baz-service",
+					PVCName:          "foo",
 					Namespace:        "bar",
 					ExternalEndpoint: "1.2.3.4:2049",
 				},
@@ -117,7 +119,8 @@ func TestReconcile(t *testing.T) {
 			wantVolumes: storageos.SharedVolumeList{
 				{
 					ID:               "1234",
-					Name:             "foo",
+					ServiceName:      "baz-service",
+					PVCName:          "foo",
 					Namespace:        "bar",
 					ExternalEndpoint: "1.2.3.4:2049",
 				},
@@ -129,23 +132,26 @@ func TestReconcile(t *testing.T) {
 			pvcs: []runtime.Object{fooPVC},
 			volumes: []*storageos.SharedVolume{
 				{
-					ID:        "1234",
-					Name:      "foo",
-					Namespace: "bar",
+					ID:          "1234",
+					ServiceName: "baz-service",
+					PVCName:     "foo",
+					Namespace:   "bar",
 				},
 			},
 			cached: []*storageos.SharedVolume{
 				{
-					ID:        "1234",
-					Name:      "foo",
-					Namespace: "bar",
+					ID:          "1234",
+					ServiceName: "baz-service",
+					PVCName:     "foo",
+					Namespace:   "bar",
 				},
 			},
 			wantVolumes: storageos.SharedVolumeList{
 				{
-					ID:        "1234",
-					Name:      "foo",
-					Namespace: "bar",
+					ID:          "1234",
+					ServiceName: "baz-service",
+					PVCName:     "foo",
+					Namespace:   "bar",
 				},
 			},
 		},
@@ -155,22 +161,24 @@ func TestReconcile(t *testing.T) {
 			cacheExpiry: time.Nanosecond,
 			volumes: []*storageos.SharedVolume{
 				{
-					ID:        "1234",
-					Name:      "foo",
-					Namespace: "bar",
+					ID:          "1234",
+					ServiceName: "baz-service",
+					PVCName:     "foo",
+					Namespace:   "bar",
 				},
 			},
 			cached: []*storageos.SharedVolume{
 				{
-					ID:        "1234",
-					Name:      "foo",
-					Namespace: "bar",
+					ID:          "1234",
+					ServiceName: "baz-service",
+					PVCName:     "foo",
+					Namespace:   "bar",
 				},
 			},
 			wantServices: []corev1.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
+						Name:      "baz-service",
 						Namespace: "bar",
 						Labels: map[string]string{
 							"storageos.com/sharedvolume": "1234",
@@ -203,7 +211,8 @@ func TestReconcile(t *testing.T) {
 			wantVolumes: storageos.SharedVolumeList{
 				{
 					ID:               "1234",
-					Name:             "foo",
+					ServiceName:      "baz-service",
+					PVCName:          "foo",
 					Namespace:        "bar",
 					ExternalEndpoint: "192.168.1.1:2049",
 				},
@@ -215,7 +224,8 @@ func TestReconcile(t *testing.T) {
 			volumes: []*storageos.SharedVolume{
 				{
 					ID:               "1234",
-					Name:             "foo",
+					ServiceName:      "baz-service",
+					PVCName:          "foo",
 					Namespace:        "bar",
 					InternalEndpoint: "1.2.3.4:1234",
 				},
@@ -224,7 +234,8 @@ func TestReconcile(t *testing.T) {
 			cached: []*storageos.SharedVolume{
 				{
 					ID:               "1234",
-					Name:             "foo",
+					ServiceName:      "baz-service",
+					PVCName:          "foo",
 					Namespace:        "bar",
 					InternalEndpoint: "1.2.3.4:5678",
 				},
@@ -232,7 +243,7 @@ func TestReconcile(t *testing.T) {
 			wantServices: []corev1.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
+						Name:      "baz-service",
 						Namespace: "bar",
 						Labels: map[string]string{
 							"storageos.com/sharedvolume": "1234",
@@ -263,7 +274,8 @@ func TestReconcile(t *testing.T) {
 			wantCached: []*storageos.SharedVolume{
 				{
 					ID:               "1234",
-					Name:             "foo",
+					ServiceName:      "baz-service",
+					PVCName:          "foo",
 					Namespace:        "bar",
 					InternalEndpoint: "1.2.3.4:1234",
 					ExternalEndpoint: "10.10.10.1:2049",
@@ -272,7 +284,8 @@ func TestReconcile(t *testing.T) {
 			wantVolumes: storageos.SharedVolumeList{
 				{
 					ID:               "1234",
-					Name:             "foo",
+					ServiceName:      "baz-service",
+					PVCName:          "foo",
 					Namespace:        "bar",
 					InternalEndpoint: "1.2.3.4:1234",
 					ExternalEndpoint: "10.10.10.1:2049",

--- a/internal/controllers/sharedvolume_e2e_test.go
+++ b/internal/controllers/sharedvolume_e2e_test.go
@@ -34,7 +34,7 @@ var _ = Describe("SharedVolume Controller", func() {
 		It("Should create service and update SharedVolume", func() {
 			v := api.RandomVol()
 			key := types.NamespacedName{
-				Name:      v.Name,
+				Name:      v.ServiceName,
 				Namespace: v.Namespace,
 			}
 
@@ -45,7 +45,7 @@ var _ = Describe("SharedVolume Controller", func() {
 					Kind:       "PersistentVolumeClaim",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      v.Name,
+					Name:      v.PVCName,
 					Namespace: v.Namespace,
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
@@ -95,7 +95,7 @@ var _ = Describe("SharedVolume Controller", func() {
 		It("Should create endpoints", func() {
 			v := api.RandomVol()
 			key := types.NamespacedName{
-				Name:      v.Name,
+				Name:      v.ServiceName,
 				Namespace: v.Namespace,
 			}
 
@@ -107,7 +107,7 @@ var _ = Describe("SharedVolume Controller", func() {
 					Kind:       "PersistentVolumeClaim",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      v.Name,
+					Name:      v.PVCName,
 					Namespace: v.Namespace,
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
@@ -150,7 +150,7 @@ var _ = Describe("SharedVolume Controller", func() {
 		It("Should not change the service", func() {
 			v := api.RandomVol()
 			key := types.NamespacedName{
-				Name:      v.Name,
+				Name:      v.ServiceName,
 				Namespace: v.Namespace,
 			}
 
@@ -162,7 +162,7 @@ var _ = Describe("SharedVolume Controller", func() {
 					Kind:       "PersistentVolumeClaim",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      v.Name,
+					Name:      v.PVCName,
 					Namespace: v.Namespace,
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
@@ -193,7 +193,8 @@ var _ = Describe("SharedVolume Controller", func() {
 			By("Changing SharedVolume InternalEndpoint")
 			Expect(api.Set(&storageos.SharedVolume{
 				ID:               v.ID,
-				Name:             v.Name,
+				ServiceName:      v.ServiceName,
+				PVCName:          v.PVCName,
 				Namespace:        v.Namespace,
 				InternalEndpoint: "5.6.7.8:9999",
 			})).ShouldNot(BeNil())
@@ -207,7 +208,7 @@ var _ = Describe("SharedVolume Controller", func() {
 		It("Should update the endpoints", func() {
 			v := api.RandomVol()
 			key := types.NamespacedName{
-				Name:      v.Name,
+				Name:      v.ServiceName,
 				Namespace: v.Namespace,
 			}
 
@@ -219,7 +220,7 @@ var _ = Describe("SharedVolume Controller", func() {
 					Kind:       "PersistentVolumeClaim",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      v.Name,
+					Name:      v.PVCName,
 					Namespace: v.Namespace,
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
@@ -248,7 +249,8 @@ var _ = Describe("SharedVolume Controller", func() {
 			By("Changing SharedVolume InternalEndpoint")
 			Expect(api.Set(&storageos.SharedVolume{
 				ID:               v.ID,
-				Name:             v.Name,
+				ServiceName:      v.ServiceName,
+				PVCName:          v.PVCName,
 				Namespace:        v.Namespace,
 				InternalEndpoint: "5.6.7.8:9999",
 			})).ShouldNot(BeNil())
@@ -288,7 +290,7 @@ var _ = Describe("SharedVolume Controller", func() {
 		It("Should not delete the service", func() {
 			v := api.RandomVol()
 			key := types.NamespacedName{
-				Name:      v.Name,
+				Name:      v.ServiceName,
 				Namespace: v.Namespace,
 			}
 
@@ -300,7 +302,7 @@ var _ = Describe("SharedVolume Controller", func() {
 					Kind:       "PersistentVolumeClaim",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      v.Name,
+					Name:      v.PVCName,
 					Namespace: v.Namespace,
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
@@ -343,7 +345,7 @@ var _ = Describe("SharedVolume Controller", func() {
 		It("Should not delete the endpoints", func() {
 			v := api.RandomVol()
 			key := types.NamespacedName{
-				Name:      v.Name,
+				Name:      v.ServiceName,
 				Namespace: v.Namespace,
 			}
 
@@ -355,7 +357,7 @@ var _ = Describe("SharedVolume Controller", func() {
 					Kind:       "PersistentVolumeClaim",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      v.Name,
+					Name:      v.PVCName,
 					Namespace: v.Namespace,
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{

--- a/internal/pkg/storageos/mock_client.go
+++ b/internal/pkg/storageos/mock_client.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func init() {
@@ -95,7 +97,8 @@ func (c *MockClient) Reset() {
 func (c *MockClient) RandomVol() *SharedVolume {
 	return &SharedVolume{
 		ID:               randomString(32),
-		Name:             randomString(8),
+		ServiceName:      "pvc-" + uuid.New().String(),
+		PVCName:          randomString(8),
 		Namespace:        "default",
 		InternalEndpoint: fmt.Sprintf("%d.%d.%d.%d:%d", rand.Intn(253)+1, rand.Intn(253)+1, rand.Intn(253)+1, rand.Intn(253)+1, rand.Intn(65534)+1),
 	}


### PR DESCRIPTION
The RWX Service should be named afater the PV, not the PVC that created it.  The PV name is unique across the cluster, and allocated immediately before the Service is created.  The PVC name is not suitable as it is common for applications to name the PVC the same as the application Service.



