### PR TITLE
Add workflows to publish to redhat container registry

### DIFF
--- a/.github/workflows/redhat-image.yml
+++ b/.github/workflows/redhat-image.yml
@@ -1,0 +1,34 @@
+name: Publish image to redhat registry
+
+on:
+  workflow_dispatch:
+    # Enable manual trigger of this action.
+    inputs:
+      gitRef:
+        description: The git branch, tag or SHA to build the image from.
+        required: true
+      imageTag:
+        description: Image tag, e.g. `v1.0.0-3`.
+        required: true
+
+jobs:
+  publish-image:
+    runs-on: ubuntu-latest
+    name: Publish image
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.gitRef }}
+      - name: Login to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: scan.connect.redhat.com
+          username: ${{ secrets.RH_USERNAME }}
+          password: ${{ secrets.RH_TOKEN }}
+      - name: Set image env var
+        run: echo "IMG=scan.connect.redhat.com/${{ secrets.OSPID }}/api-manager:${{ github.event.inputs.imageTag }}" >> $GITHUB_ENV
+      - name: Build container image
+        run: make docker-build
+      - name: Publish image
+        run: make docker-push

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -12,10 +12,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set image env
+      - name: Set image tag env var
         # Refer https://stackoverflow.com/a/58178121 for git tag extraction.
-        run: echo ::set-env name=IMG::storageos/api-manager:${GITHUB_REF#refs/*/}
-      - name: Login to container registry
+        run: echo "IMG_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Set image env vars
+        run: |
+          echo "IMG=storageos/api-manager:${{ env.IMG_TAG }}" >> $GITHUB_ENV
+          echo "RH_IMG=scan.connect.redhat.com/${{ secrets.OSPID }}/api-manager:${{ env.IMG_TAG }}" >> $GITHUB_ENV
+      - name: Login to docker container registry
         uses: docker/login-action@v1
         with:
           registry: docker.io
@@ -23,5 +27,15 @@ jobs:
           password: ${{ secrets.CR_PAT }}
       - name: Build container image
         run: make docker-build
-      - name: Push container image
+      - name: Push container image to dockerhub
         run: make docker-push
+      - name: Login to redhat container registry
+        uses: docker/login-action@v1
+        with:
+          registry: scan.connect.redhat.com
+          username: ${{ secrets.RH_USERNAME }}
+          password: ${{ secrets.RH_TOKEN }}
+      - name: Push container image to redhat container registry
+        run: |
+          docker tag ${{ env.IMG }} ${{ env.RH_IMG }}
+          make docker-push IMG=${{ env.RH_IMG }}


### PR DESCRIPTION
- Add steps to "Publish release image" workflow publish-image job to
tag and push the release image to redhat container registry.
- Add new workflow to manually trigger an image build, based on a
branch, tag or SHA, tag the image and push to redhat container registry.