### PR TITLE
Bump golangci-lint-action

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2.2.0
+        uses: golangci/golangci-lint-action@v2.3.0
         with:
           args: --timeout=5m
 


### PR DESCRIPTION
Pipelines were failing due to https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

This fixes them.