### PR TITLE
Add node delete controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN go mod download
 
 # Copy the go source
 COPY main.go main.go
+COPY controllers/ controllers/
 COPY internal/ internal/
 
 # Build

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Endpoint will be updated, but the Service ClusterIP will remain the same.
 See [Shared Volume Contoller](internal/controllers/sharedvolume/README.md) for
 more detail.
 
+### Node Delete Controller
+
+The Node Delete Controller is responsible for removing nodes from the StorageOS
+cluster when the node has been removed from Kubernetes.
+
+See [Node Delete Contoller](controllers/node-delete/README.md) for more detail.
+
 ## Initialization
 
 Startup blocks on obtaining a connection to the StorageOS control plane API,
@@ -64,8 +71,8 @@ The following flags are supported:
     	Frequency of StorageOS api authentication token refresh. (default 1m0s)
   -api-retry-interval duration
     	Frequency of StorageOS api retries on failure. (default 5s)
-  -api-secret-path path
-    	Path where the StorageOS api secret is mounted.  The secret must have username and `password` set. (default "/etc/storageos/secrets/api")
+  -api-secret-path string
+    	Path where the StorageOS api secret is mounted.  The secret must have "username" and "password" set. (default "/etc/storageos/secrets/api")
   -cache-expiry-interval duration
     	Frequency of cached volume re-validation. (default 1m0s)
   -enable-leader-election
@@ -80,6 +87,9 @@ The following flags are supported:
     	(Deprecated: switch to --kubeconfig) The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.
   -metrics-addr string
     	The address the metric endpoint binds to. (default ":8080")
+  -node-delete-workers int
+    	Maximum concurrent node delete operations. (default 5)
+
 ```
 
 ## Setup/Development

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -29,6 +29,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create

--- a/controllers/node-delete/README.md
+++ b/controllers/node-delete/README.md
@@ -1,0 +1,31 @@
+# Node Delete Controller
+
+The Node Delete Controller is responsible for removing nodes from the StorageOS
+cluster when the node has been removed from Kubernetes.
+
+The intention is to allow StorageOS to adapt to dynamic environments where nodes
+are added and removed regularly, such as when spot instances are used.
+
+Removing nodes when they are no longer required reduces load as StorageOS will
+no longer check for the node recovering.
+
+## Trigger
+
+The controller reconcile will trigger on any Kubernetes Node delete event where
+the node has the StorageOS CSI driver annotation.
+
+The annotation is added by the CSI node driver registrar when StorageOS starts
+on the node.  Once added, it is not removed.
+
+## Reconcile
+
+When a Kubernetes node with the StorageOS driver annotation is deleted, a
+request is made to the StorageOS API to remove the node.  The StorageOS API will
+only allow the delete to succeed if the node has been marked offline (typically
+discovered 20-30 seconds after it goes off the network).
+
+If the delete request failed, it will be requeued and retried after a backoff
+period.
+
+If the node was not found because it has already been deleted, the delete
+request will be considered successful.

--- a/controllers/node-delete/controller.go
+++ b/controllers/node-delete/controller.go
@@ -1,0 +1,121 @@
+package nodedelete
+
+import (
+	"encoding/json"
+
+	"github.com/go-logr/logr"
+	"github.com/storageos/api-manager/internal/pkg/storageos"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const (
+	// DriverName is the name of the StorageOS CSI driver.
+	DriverName = "csi.storageos.com"
+
+	// DriverAnnotationKey is the annotation that stores the registered CSI
+	// drivers.
+	DriverAnnotationKey = "csi.volume.kubernetes.io/nodeid"
+)
+
+// Reconciler reconciles a Node object by deleting the StorageOS node object
+// when the corresponding Kubernetes node is deleted.
+type Reconciler struct {
+	client.Client
+	Log logr.Logger
+	api storageos.NodeDeleter
+}
+
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+
+// NewReconciler returns a new Node delete reconciler.
+func NewReconciler(api storageos.NodeDeleter, k8s client.Client) *Reconciler {
+	return &Reconciler{
+		Client: k8s,
+		Log:    ctrl.Log.WithName("controllers").WithName("NodeDelete"),
+		api:    api,
+	}
+}
+
+// SetupWithManager registers the controller with the controller manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, workers int) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: workers}).
+		For(&corev1.Node{}).
+		WithEventFilter(ChangePredicate{log: r.Log}).
+		Complete(r)
+}
+
+// Reconcile deletes the StorageOS node.  The delete will fail if the control
+// plane has not yet determined that the node is offline.  Any errors will
+// result in a requeue, with standard back-off retries.
+//
+// Events are not sent as they require an object. By this point the namespace
+// object will no longer be available.
+func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	err := r.api.DeleteNode(req.Name)
+	if err != nil && err != storageos.ErrNodeNotFound {
+		// Re-queue without error.  We will get frequent transient errors, such
+		// as version conflicts or locked objects - that's ok.  Even refusal to
+		// delete due to the node still showing as online should be seen as
+		// transient and should not raise an error.
+		return ctrl.Result{Requeue: true}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+// ChangePredicate filters events before enqueuing the keys.
+type ChangePredicate struct {
+	predicate.Funcs
+	log logr.Logger
+}
+
+// Create determines whether an object create should trigger a reconcile.
+func (c ChangePredicate) Create(event.CreateEvent) bool {
+	return false
+}
+
+// Update determines whether an object update should trigger a reconcile.
+func (c ChangePredicate) Update(event.UpdateEvent) bool {
+	return false
+}
+
+// Delete determines whether an object delete should trigger a reconcile.
+func (c ChangePredicate) Delete(e event.DeleteEvent) bool {
+	// Ignore objects without metadata.
+	if e.Meta == nil {
+		return false
+	}
+	found, err := hasStorageOSDriverAnnotation(e.Meta.GetAnnotations())
+	if err != nil {
+		c.log.Error(err, "failed to process node annotations", "node", e.Meta.GetName())
+	}
+	return found
+}
+
+// Generic determines whether an generic event should trigger a reconcile.
+func (c ChangePredicate) Generic(event.GenericEvent) bool {
+	return false
+}
+
+// hasStorageOSDriverAnnotation returns true if the node has the StorageOS
+// driver annotation.  The annotation is added by the drivers' node registrar,
+// so should only be present on nodes that have run StorageOS.
+func hasStorageOSDriverAnnotation(annotations map[string]string) (bool, error) {
+	drivers, ok := annotations[DriverAnnotationKey]
+	if !ok {
+		return false, nil
+	}
+	driversMap := map[string]string{}
+	if err := json.Unmarshal([]byte(drivers), &driversMap); err != nil {
+		return false, err
+	}
+	if _, ok := driversMap[DriverName]; ok {
+		return true, nil
+	}
+	return false, nil
+}

--- a/controllers/node-delete/controller_test.go
+++ b/controllers/node-delete/controller_test.go
@@ -1,0 +1,64 @@
+package nodedelete
+
+import (
+	"testing"
+)
+
+func Test_hasStorageOSDriverAnnotation(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+		wantErr     bool
+	}{
+		{
+			name:        "no annotations",
+			annotations: map[string]string{},
+			want:        false,
+		},
+		{
+			name: "no csi annotations",
+			annotations: map[string]string{
+				"foo": "bar",
+			},
+			want: false,
+		},
+		{
+			name: "no storageos csi annotation",
+			annotations: map[string]string{
+				"foo":               "bar",
+				DriverAnnotationKey: "{\"csi.xyz.com\":\"f4bfe4d3-fed0-47f0-bc89-e983670f25a9\"}",
+			},
+			want: false,
+		},
+		{
+			name: "storageos csi annotation",
+			annotations: map[string]string{
+				"foo":               "bar",
+				DriverAnnotationKey: "{\"csi.storageos.com\":\"f4bfe4d3-fed0-47f0-bc89-e983670f25a9\"}",
+			},
+			want: true,
+		},
+		{
+			name: "badly formatted csi annotation",
+			annotations: map[string]string{
+				"foo":               "bar",
+				DriverAnnotationKey: "{\"csi.storageos.com\":}",
+			},
+			want:    false,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		var tt = tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := hasStorageOSDriverAnnotation(tt.annotations)
+			if (gotErr != nil) != tt.wantErr {
+				t.Errorf("hasStorageOSDriverAnnotation() error = %v, wantErr %t", gotErr, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("hasStorageOSDriverAnnotation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/controllers/node_delete_test.go
+++ b/controllers/node_delete_test.go
@@ -1,0 +1,166 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	nodedelete "github.com/storageos/api-manager/controllers/node-delete"
+	"github.com/storageos/api-manager/internal/pkg/storageos"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	nodeDeleteTestWorkers = 1
+)
+
+// SetupNodeDeleteTest will set up a testing environment.  It must be called
+// from each test.
+func SetupNodeDeleteTest(ctx context.Context, isStorageOS bool) *corev1.Node {
+	var stopCh chan struct{}
+	node := &corev1.Node{}
+
+	BeforeEach(func() {
+		stopCh = make(chan struct{})
+
+		*node = corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "testnode-" + randStringRunes(5)},
+		}
+
+		if isStorageOS {
+			driverMap, err := json.Marshal(map[string]string{
+				nodedelete.DriverName: uuid.New().String(),
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to mars")
+			node.Annotations = map[string]string{
+				nodedelete.DriverAnnotationKey: string(driverMap),
+			}
+		}
+
+		err := k8sClient.Create(ctx, node)
+		Expect(err).NotTo(HaveOccurred(), "failed to create test node")
+
+		api = storageos.NewMockClient()
+		err = api.AddNode(node.Name)
+		Expect(err).NotTo(HaveOccurred(), "failed to create test node in storageos")
+
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{})
+		Expect(err).NotTo(HaveOccurred(), "failed to create manager")
+
+		controller := nodedelete.NewReconciler(api, mgr.GetClient())
+		err = controller.SetupWithManager(mgr, nodeDeleteTestWorkers)
+		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
+
+		go func() {
+			err := mgr.Start(stopCh)
+			Expect(err).NotTo(HaveOccurred(), "failed to start manager")
+		}()
+
+		// Wait for manager to be ready.
+		time.Sleep(managerWaitDuration)
+	})
+
+	AfterEach(func() {
+		close(stopCh)
+		// Don't delete the node, the test should have.
+	})
+
+	return node
+}
+
+var _ = Describe("Node Delete controller", func() {
+	// Define utility constants for object names and testing timeouts/durations
+	// and intervals.
+	const (
+		timeout  = time.Second * 10
+		duration = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	ctx := context.Background()
+
+	Context("When deleting a k8s Node with the StorageOS driver registered", func() {
+		node := SetupNodeDeleteTest(ctx, true)
+		It("Should delete the StorageOS Node", func() {
+			By("By deleting the k8s Node")
+			Expect(k8sClient.Delete(ctx, node)).Should(Succeed())
+
+			By("Expecting StorageOS Node to be deleted")
+			Eventually(func() bool {
+				return api.NodeExists(node.Name)
+			}, timeout, interval).Should(BeFalse())
+		})
+	})
+
+	Context("When deleting a k8s Node and the StorageOS node has already been deleted", func() {
+		node := SetupNodeDeleteTest(ctx, true)
+		It("Should not fail", func() {
+			Expect(api.DeleteNode(node.Name)).Should(Succeed())
+			api.DeleteNodeErr = storageos.ErrNodeNotFound
+
+			By("By deleting the k8s Node")
+			Expect(k8sClient.Delete(ctx, node)).Should(Succeed())
+
+			By("Expecting StorageOS Node to be deleted")
+			Eventually(func() bool {
+				return api.NodeExists(node.Name)
+			}, timeout, interval).Should(BeFalse())
+		})
+	})
+
+	Context("When deleting a k8s Node without the StorageOS driver registration", func() {
+		node := SetupNodeDeleteTest(ctx, false)
+		It("Should not delete the StorageOS Node", func() {
+			By("By deleting the k8s Node")
+			Expect(k8sClient.Delete(ctx, node)).Should(Succeed())
+
+			By("Expecting StorageOS Node to not be deleted")
+			Consistently(func() bool {
+				return api.NodeExists(node.Name)
+			}, duration, interval).Should(BeTrue())
+		})
+	})
+
+	Context("When deleting a k8s Node with a malformed StorageOS driver registration", func() {
+		node := SetupNodeDeleteTest(ctx, false)
+		It("Should not delete the StorageOS Node", func() {
+			By("By setting an invalid annotation")
+			node.Annotations = map[string]string{
+				nodedelete.DriverAnnotationKey: "{\"csi.storageos.com\":}",
+			}
+			Expect(k8sClient.Update(ctx, node, &client.UpdateOptions{})).Should(Succeed())
+
+			By("By deleting the k8s Node")
+			Expect(k8sClient.Delete(ctx, node)).Should(Succeed())
+
+			By("Expecting StorageOS Node to not be deleted")
+			Consistently(func() bool {
+				return api.NodeExists(node.Name)
+			}, duration, interval).Should(BeTrue())
+		})
+	})
+
+	Context("When deleting a k8s Node that still has volumes", func() {
+		node := SetupNodeDeleteTest(ctx, true)
+		It("Should not delete the StorageOS Node", func() {
+			By("By causing the StorageOS Node delete to fail")
+			api.DeleteNodeErr = errors.New("delete failed")
+
+			By("By deleting the k8s Node")
+			Expect(k8sClient.Delete(ctx, node)).Should(Succeed())
+
+			By("Expecting StorageOS Node to not be deleted")
+			Consistently(func() bool {
+				return api.NodeExists(node.Name)
+			}, duration, interval).Should(BeTrue())
+		})
+	})
+
+})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -1,0 +1,87 @@
+package controllers
+
+import (
+	"math/rand"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/storageos/api-manager/internal/pkg/storageos"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	// +kubebuilder:scaffold:imports
+)
+
+const (
+	// managerWaitDuration is the time to wait for the manager to start and be
+	// ready to process events.  The manager starts asychronously, so without a
+	// wait, events may be missed.
+	managerWaitDuration = 1 * time.Second
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+// +kubebuilder:docs-gen:collapse=Imports
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var api *storageos.MockClient
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	// Read CRDs from the CRD directory.
+	By("Bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
+	}
+
+	// Start the envtest cluster.
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(k8sClient).ToNot(BeNil())
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("Tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controller Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz1234567890")
+
+func randStringRunes(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}

--- a/internal/pkg/storageos/node.go
+++ b/internal/pkg/storageos/node.go
@@ -1,0 +1,61 @@
+package storageos
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/storageos/api-manager/internal/pkg/storageos/metrics"
+	api "github.com/storageos/go-api/v2"
+)
+
+var (
+	// ErrNodeNotFound is returned if a node was provided but it was not found.
+	ErrNodeNotFound = errors.New("node not found")
+)
+
+//NodeDeleter provides access to removing nodes from StorageOS.
+type NodeDeleter interface {
+	DeleteNode(name string) error
+}
+
+// DeleteNode removes a node from the StorageOS cluster.  Delete will fail if
+// pre-requisites are not met (i.e. no active volumes).
+func (c *Client) DeleteNode(name string) error {
+	funcName := "delete_node"
+	start := time.Now()
+	defer func() {
+		metrics.Latency.Observe(funcName, time.Since(start))
+	}()
+	observeErr := func(e error) error {
+		metrics.Errors.Increment(funcName, GetAPIErrorRootCause(e))
+		return e
+	}
+
+	ctx, cancel := context.WithTimeout(c.ctx, DefaultRequestTimeout)
+	defer cancel()
+
+	node, err := c.getNodeByName(ctx, name)
+	if err != nil {
+		return observeErr(err)
+	}
+
+	if _, err = c.api.DefaultApi.DeleteNode(ctx, node.Id, node.Version, nil); err != nil {
+		return observeErr(err)
+	}
+	return observeErr(nil)
+}
+
+// getNodeByName returns the StorageOS node object matching the name, if any.
+func (c *Client) getNodeByName(ctx context.Context, name string) (*api.Node, error) {
+	nodes, _, err := c.api.DefaultApi.ListNodes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, node := range nodes {
+		if node.Name == name {
+			return &node, nil
+		}
+	}
+	return nil, ErrNodeNotFound
+}


### PR DESCRIPTION
Adds a controller to watch for Kubernetes Node delete events, and to remove the node from the StorageOS cluster if safe.