### PR TITLE
Add namespace delete controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ cluster when the node has been removed from Kubernetes.
 
 See [Node Delete Contoller](controllers/node-delete/README.md) for more detail.
 
+### Namespace Delete Controller
+
+The Namespace Delete Controller is responsible for removing namespaces from the
+StorageOS cluster when the namespace has been removed from Kubernetes.
+
+See [Namespace Delete Controller](controllers/namespace-delete/README.md) for
+more detail.
+
 ## Initialization
 
 Startup blocks on obtaining a connection to the StorageOS control plane API,
@@ -87,9 +95,10 @@ The following flags are supported:
     	(Deprecated: switch to --kubeconfig) The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.
   -metrics-addr string
     	The address the metric endpoint binds to. (default ":8080")
+  -namespace-delete-workers int
+    	Maximum concurrent namespace delete operations. (default 5)
   -node-delete-workers int
-    	Maximum concurrent node delete operations. (default 5)
-
+    	Maximum concurrent node delete operations. (default 5)      
 ```
 
 ## Setup/Development

--- a/controllers/namespace-delete/README.md
+++ b/controllers/namespace-delete/README.md
@@ -1,0 +1,35 @@
+# Namespace Delete Controller
+
+The Namespace Delete Controller is responsible for removing namesapces from the
+StorageOS cluster when the namespace has been removed from Kubernetes.
+
+When a StorageOS-provisioned PVC is created in a Kubernetes namespace, if the
+namespace does not already exist in the StorageOS cluster then it is created and
+the StorageOS volume is created within it.
+
+The opposite is not true - the StorageOS control plane does not remove
+namespaces after the last volume has been removed from it, as it can't tell
+whether a new volume will be provisioned to it.  This can lead to multiple empty
+namespaces remaining in the cluster, unless they are deleted manually using the
+UI or CLI.
+
+If the Kubernetes namespace is deleted, then we can safely assume that the
+namespace is no longer needed, and that it will be re-created if a new PVC is
+provisioned to it.  Only empty namespaces will be deleted.
+
+## Trigger
+
+The controller reconcile will trigger on any Kubernetes Namespace delete event.
+
+## Reconcile
+
+When a Kubernetes namespace is deleted, a request is made to the StorageOS API to
+remove the namespace.  The StorageOS API will only allow the delete to succeed if the
+namespace is empty and does not contain any volumes.
+
+If the delete request failed, it will be requeued and retried after a backoff
+period.
+
+If the namespace was not found, either because it was already deleted or it
+never had a PVC provisioned by StorageOS, the delete request will be considered
+successful.

--- a/controllers/namespace-delete/controller.go
+++ b/controllers/namespace-delete/controller.go
@@ -1,0 +1,84 @@
+package nsdelete
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/storageos/api-manager/internal/pkg/storageos"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// Reconciler reconciles a Namespace object by deleting the StorageOS namespace
+// when the corresponding Kubernetes namespace is deleted.
+type Reconciler struct {
+	client.Client
+	Log logr.Logger
+	api storageos.NamespaceDeleter
+}
+
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+
+// NewReconciler returns a new Namespace delete reconciler.
+func NewReconciler(api storageos.NamespaceDeleter, k8s client.Client) *Reconciler {
+	return &Reconciler{
+		Client: k8s,
+		Log:    ctrl.Log.WithName("controllers").WithName("NamespaceDelete"),
+		api:    api,
+	}
+}
+
+// SetupWithManager registers the controller with the controller manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, workers int) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: workers}).
+		For(&corev1.Namespace{}).
+		WithEventFilter(ChangePredicate{}).
+		Complete(r)
+}
+
+// Reconcile deletes the StorageOS namespace.  The delete will fail if there are
+// still volumes in the namespace.  Any errors will result in a requeue, with
+// standard back-off retries.
+//
+// Events are not sent as they require an object. By this point the namespace
+// object will no longer be available.
+func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	err := r.api.DeleteNamespace(req.Name)
+	if err != nil && err != storageos.ErrNamespaceNotFound {
+		// Re-queue without error.  We will get frequent transient errors, such
+		// as version conflicts or locked objects - that's ok.  Even refusal to
+		// delete due to remaining volumes should be seen as transient and
+		// should not raise an error.
+		return ctrl.Result{Requeue: true}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+// ChangePredicate filters events before enqueuing the keys.
+type ChangePredicate struct {
+	predicate.Funcs
+}
+
+// Create determines whether an object create should trigger a reconcile.
+func (ChangePredicate) Create(event.CreateEvent) bool {
+	return false
+}
+
+// Update determines whether an object update should trigger a reconcile.
+func (ChangePredicate) Update(event.UpdateEvent) bool {
+	return false
+}
+
+// Delete determines whether an object delete should trigger a reconcile.
+func (ChangePredicate) Delete(e event.DeleteEvent) bool {
+	// Ignore objects without metadata.
+	return e.Meta != nil
+}
+
+// Generic determines whether an generic event should trigger a reconcile.
+func (ChangePredicate) Generic(event.GenericEvent) bool {
+	return false
+}

--- a/controllers/namespace_delete_test.go
+++ b/controllers/namespace_delete_test.go
@@ -1,0 +1,141 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	nsdelete "github.com/storageos/api-manager/controllers/namespace-delete"
+	"github.com/storageos/api-manager/internal/pkg/storageos"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	nsDeleteTestWorkers = 1
+)
+
+// SetupNamespaceDeleteTest will set up a testing environment.  It must be
+// called from each test.
+func SetupNamespaceDeleteTest(ctx context.Context) *corev1.Namespace {
+	var stopCh chan struct{}
+	ns := &corev1.Namespace{}
+
+	BeforeEach(func() {
+		stopCh = make(chan struct{})
+		*ns = corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "testns-" + randStringRunes(5)},
+		}
+
+		err := k8sClient.Create(ctx, ns)
+		Expect(err).NotTo(HaveOccurred(), "failed to create test namespace")
+
+		api = storageos.NewMockClient()
+		err = api.AddNamespace(ns.Name)
+		Expect(err).NotTo(HaveOccurred(), "failed to create test namespace in storageos")
+
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{})
+		Expect(err).NotTo(HaveOccurred(), "failed to create manager")
+
+		controller := nsdelete.NewReconciler(api, mgr.GetClient())
+		err = controller.SetupWithManager(mgr, nsDeleteTestWorkers)
+		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
+
+		go func() {
+			err := mgr.Start(stopCh)
+			Expect(err).NotTo(HaveOccurred(), "failed to start manager")
+		}()
+
+		// Wait for manager to be ready.
+		time.Sleep(managerWaitDuration)
+	})
+
+	AfterEach(func() {
+		close(stopCh)
+		// Don't delete the namespace, the test should have.
+	})
+
+	return ns
+}
+
+var _ = Describe("Namespace Delete controller", func() {
+	// Define utility constants for object names and testing timeouts/durations
+	// and intervals.
+	const (
+		timeout  = time.Second * 10
+		duration = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	ctx := context.Background()
+
+	Context("When deleting a k8s Namespace", func() {
+		ns := SetupNamespaceDeleteTest(ctx)
+		It("Should delete the StorageOS Namespace", func() {
+			// Skip test if running in envtest.  envtest doesn't handle namespace
+			// deletion in the same way as other objects, so the delete event is never
+			// sent: https://github.com/kubernetes-sigs/controller-runtime/issues/880
+			if val, ok := os.LookupEnv("USE_EXISTING_CLUSTER"); !ok || val == "false" {
+				Skip("Namespace delete events not seen in envtest")
+			}
+
+			By("By deleting the k8s Namespace")
+			Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+
+			By("Expecting StorageOS Namespace to be deleted")
+			Eventually(func() bool {
+				return api.NamespaceExists(ns.Name)
+			}, timeout, interval).Should(BeFalse())
+		})
+	})
+
+	Context("When deleting a k8s Namespace and the StorageOS Namespace has already been deleted", func() {
+		ns := SetupNamespaceDeleteTest(ctx)
+		It("Should not fail", func() {
+			// Skip test if running in envtest.  envtest doesn't handle namespace
+			// deletion in the same way as other objects, so the delete event is never
+			// sent: https://github.com/kubernetes-sigs/controller-runtime/issues/880
+			if val, ok := os.LookupEnv("USE_EXISTING_CLUSTER"); !ok || val == "false" {
+				Skip("Namespace delete events not seen in envtest")
+			}
+			Expect(api.DeleteNamespace(ns.Name)).Should(Succeed())
+			api.DeleteNamespaceErr = storageos.ErrNamespaceNotFound
+
+			By("By deleting the k8s Namespace")
+			Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+
+			By("Expecting StorageOS Namespace to be deleted")
+			Eventually(func() bool {
+				return api.NamespaceExists(ns.Name)
+			}, timeout, interval).Should(BeFalse())
+		})
+	})
+
+	Context("When deleting a k8s Namespace that still has volumes", func() {
+		ns := SetupNamespaceDeleteTest(ctx)
+		It("Should not delete the StorageOS Namespace", func() {
+			// Skip test if running in envtest.  envtest doesn't handle namespace
+			// deletion in the same way as other objects, so the delete event is never
+			// sent: https://github.com/kubernetes-sigs/controller-runtime/issues/880
+			if val, ok := os.LookupEnv("USE_EXISTING_CLUSTER"); !ok || val == "false" {
+				Skip("Namespace delete events not seen in envtest")
+			}
+
+			By("By causing the StorageOS Namespace delete to fail")
+			api.DeleteNamespaceErr = errors.New("delete failed")
+
+			By("By deleting the k8s Namespace")
+			Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+
+			By("Expecting StorageOS Namespace to not be deleted")
+			Consistently(func() bool {
+				return api.NamespaceExists(ns.Name)
+			}, duration, interval).Should(BeTrue())
+		})
+	})
+
+})

--- a/internal/pkg/storageos/namespace.go
+++ b/internal/pkg/storageos/namespace.go
@@ -1,0 +1,62 @@
+package storageos
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/storageos/api-manager/internal/pkg/storageos/metrics"
+	api "github.com/storageos/go-api/v2"
+)
+
+var (
+	// ErrNamespaceNotFound is returned if a namespace was provided but it was
+	// not found.
+	ErrNamespaceNotFound = errors.New("namespace not found")
+)
+
+//NamespaceDeleter provides access to removing namespaces from StorageOS.
+type NamespaceDeleter interface {
+	DeleteNamespace(name string) error
+}
+
+// DeleteNamespace removes a namespace from the StorageOS cluster.  Delete will fail if
+// pre-requisites are not met (i.e. namespace has volumes).
+func (c *Client) DeleteNamespace(name string) error {
+	funcName := "delete_namespace"
+	start := time.Now()
+	defer func() {
+		metrics.Latency.Observe(funcName, time.Since(start))
+	}()
+	observeErr := func(e error) error {
+		metrics.Errors.Increment(funcName, GetAPIErrorRootCause(e))
+		return e
+	}
+
+	ctx, cancel := context.WithTimeout(c.ctx, DefaultRequestTimeout)
+	defer cancel()
+
+	ns, err := c.getNamespaceByName(ctx, name)
+	if err != nil {
+		return observeErr(err)
+	}
+
+	if _, err = c.api.DefaultApi.DeleteNamespace(ctx, ns.Id, ns.Version, nil); err != nil {
+		return observeErr(err)
+	}
+	return observeErr(nil)
+}
+
+// getNamespaceByName returns the StorageOS namespace object matching the name, if any.
+func (c *Client) getNamespaceByName(ctx context.Context, name string) (*api.Namespace, error) {
+	namespaces, _, err := c.api.DefaultApi.ListNamespaces(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, ns := range namespaces {
+		if ns.Name == name {
+			return &ns, nil
+		}
+	}
+	return nil, ErrNamespaceNotFound
+}

--- a/internal/pkg/storageos/shared_volume.go
+++ b/internal/pkg/storageos/shared_volume.go
@@ -14,9 +14,6 @@ import (
 )
 
 var (
-	// ErrNamespaceNotFound is returned if a namespace was provided but it was not found.
-	ErrNamespaceNotFound = errors.New("namespace not found")
-
 	// ErrNotFound is returned if a volume was provided but it was not found.
 	ErrNotFound = errors.New("volume not found")
 


### PR DESCRIPTION
Adds a controller to watch for Kubernetes Namespace delete events, and to remove the namespace from the StorageOS cluster if it doesn't have volumes.

