### PR TITLE
Add action to ensure modules tidy & vendored

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           go-version: '1.15.2'
       - name: Run go tidy
-        run: make tidy && git diff --exit-code && test -z "$(git ls-files --exclude-standard --others)"
+        run: make tidy && git diff --exit-code && test -z "$(git ls-files --exclude-standard --others | tee /dev/fd/2)"
       - name: Run go test
         run: make test
       - name: Run go build

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -16,14 +16,6 @@ jobs:
         with:
           args: --timeout=5m
 
-  tidy:
-    name: Tidy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Run go tidy
-        run: make tidy && git diff --exit-code && test -z "$(git ls-files --exclude-standard --others)"
-
   test-build:
     name: Run tests and build
     runs-on: ubuntu-latest
@@ -32,6 +24,8 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.15.2'
+      - name: Run go tidy
+        run: make tidy && git diff --exit-code && test -z "$(git ls-files --exclude-standard --others)"
       - name: Run go test
         run: make test
       - name: Run go build

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -7,14 +7,22 @@ env:
 
 jobs:
   lint:
-    name: lint
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: golangci-lint
+      - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2.3.0
         with:
           args: --timeout=5m
+
+  tidy:
+    name: Tidy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run go tidy
+        run: make tidy && git diff --exit-code && test -z "$(git ls-files --exclude-standard --others)"
 
   test-build:
     name: Run tests and build
@@ -24,9 +32,9 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.15.2'
-      - name: go-test
+      - name: Run go test
         run: make test
-      - name: build
+      - name: Run go build
         run: make manager
 
   build-image:


### PR DESCRIPTION
Ensures changes from `go mod tidy` and `go mod vendor` have been commited.

Failure when dependency missing from vendor: https://github.com/storageos/api-manager/runs/1662859506?check_suite_focus=true