### PR TITLE
Build and tests should use vendored deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,10 @@
 FROM golang:1.15.2 as builder
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
-COPY controllers/ controllers/
-COPY internal/ internal/
+COPY . /workspace
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -mod=vendor -o manager main.go
 
 # Use ubi8-minimal as the base image to package the manager binary. Refer to
 # https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8

--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ kubebuilder:
 
 # Run tests
 test: kubebuilder generate fmt vet manifests
-	go test -timeout 300s ./... -coverprofile cover.out
+	go test -mod=vendor -timeout 300s ./... -coverprofile cover.out
 
 # Build manager binary
 manager: generate fmt vet tidy
-	go build -o bin/manager main.go
+	go build -mod=vendor -o bin/manager main.go
 
 # Prune, add and vendor go dependencies.
 tidy:
@@ -40,7 +40,7 @@ tidy:
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests secret
-	go run ./main.go -api-secret-path=$(PWD)/.secret
+	go run -mod=vendor ./main.go -api-secret-path=$(PWD)/.secret
 
 # Install CRDs into a cluster
 install: manifests


### PR DESCRIPTION
Change build and tests to use the vendored dependencies.

Also removes the code in the Dockerfile to selectively copy source files since it was intended to speed up the build by not copying in vendored deps (which we now want to do).