### PR TITLE
Migrate namespace delete to operator toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,16 @@ The following flags are supported:
     	Maximum time to wait for new Kubernetes objects to appear. (default 20s)
   -kubeconfig string
     	Paths to a kubeconfig. Only required if out-of-cluster.
-  -master --kubeconfig
-    	(Deprecated: switch to --kubeconfig) The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.
   -metrics-addr string
     	The address the metric endpoint binds to. (default ":8080")
+  -namespace-delete-gc-interval duration
+    	Frequency of node garbage collection. (default 1h0m0s)
   -namespace-delete-workers int
     	Maximum concurrent namespace delete operations. (default 5)
+  -node-delete-gc-interval duration
+    	Frequency of node garbage collection. (default 1h0m0s)
   -node-delete-workers int
-    	Maximum concurrent node delete operations. (default 5)      
+    	Maximum concurrent node delete operations. (default 5)   
 ```
 
 ## Setup/Development

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The following flags are supported:
   -metrics-addr string
     	The address the metric endpoint binds to. (default ":8080")
   -namespace-delete-gc-interval duration
-    	Frequency of node garbage collection. (default 1h0m0s)
+    	Frequency of namespace garbage collection. (default 1h0m0s)
   -namespace-delete-workers int
     	Maximum concurrent namespace delete operations. (default 5)
   -node-delete-gc-interval duration

--- a/controllers/namespace-delete/README.md
+++ b/controllers/namespace-delete/README.md
@@ -1,6 +1,6 @@
 # Namespace Delete Controller
 
-The Namespace Delete Controller is responsible for removing namesapces from the
+The Namespace Delete Controller is responsible for removing namespaces from the
 StorageOS cluster when the namespace has been removed from Kubernetes.
 
 When a StorageOS-provisioned PVC is created in a Kubernetes namespace, if the
@@ -23,9 +23,9 @@ The controller reconcile will trigger on any Kubernetes Namespace delete event.
 
 ## Reconcile
 
-When a Kubernetes namespace is deleted, a request is made to the StorageOS API to
-remove the namespace.  The StorageOS API will only allow the delete to succeed if the
-namespace is empty and does not contain any volumes.
+When a Kubernetes namespace is deleted, a request is made to the StorageOS API
+to remove the namespace.  The StorageOS API will only allow the delete to
+succeed if the namespace is empty and does not contain any volumes.
 
 If the delete request failed, it will be requeued and retried after a backoff
 period.
@@ -33,3 +33,12 @@ period.
 If the namespace was not found, either because it was already deleted or it
 never had a PVC provisioned by StorageOS, the delete request will be considered
 successful.
+
+## Garbage Collection
+
+In case a namespace delete event was missed during a restart or outage, a
+garbage collection runs periodically.  It compares the list of namespaces known
+to StorageOS, and removes any that are no longer known to Kubernetes.
+
+Garbage collection is run every hour by default (configurable via the
+`-namespace-delete-gc-interval` flag).

--- a/controllers/namespace-delete/controller.go
+++ b/controllers/namespace-delete/controller.go
@@ -37,8 +37,8 @@ func (c Controller) Ensure(ctx context.Context, obj client.Object) error {
 // to remove it from management.
 func (c Controller) Delete(ctx context.Context, obj client.Object) error {
 	err := c.api.DeleteNamespace(obj.GetName())
-	if err != nil && err != storageos.ErrNodeNotFound {
-		return errors.Wrap(err, "re-queing operation")
+	if err != nil && err != storageos.ErrNamespaceNotFound {
+		return errors.Wrap(err, "requeuing operation")
 	}
 	c.log.Info("namespace decommissioned in storageos", "name", obj.GetName())
 	return nil

--- a/controllers/namespace-delete/controller.go
+++ b/controllers/namespace-delete/controller.go
@@ -3,83 +3,51 @@ package nsdelete
 import (
 	"context"
 
-	"github.com/go-logr/logr"
-	"github.com/storageos/api-manager/internal/pkg/storageos"
-	corev1 "k8s.io/api/core/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	objectv1 "github.com/darkowlzz/operator-toolkit/controller/external-object-sync/v1"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"github.com/storageos/api-manager/internal/pkg/storageos"
 )
 
-// Reconciler reconciles a Namespace object by deleting the StorageOS namespace
-// when the corresponding Kubernetes namespace is deleted.
-type Reconciler struct {
-	client.Client
-	Log logr.Logger
+// Controller implements the SyncReconciler contoller interface, deleting
+// namespaces in StorageOS when they have been detected as deleted in
+// Kubernetes.
+type Controller struct {
 	api storageos.NamespaceDeleter
+	log logr.Logger
 }
 
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+var _ objectv1.Controller = &Controller{}
 
-// NewReconciler returns a new Namespace delete reconciler.
-func NewReconciler(api storageos.NamespaceDeleter, k8s client.Client) *Reconciler {
-	return &Reconciler{
-		Client: k8s,
-		Log:    ctrl.Log.WithName("controllers").WithName("NamespaceDelete"),
-		api:    api,
+// NewController returns a Controller that implements namespace garbage
+// collection in StorageOS.
+func NewController(api storageos.NamespaceDeleter, log logr.Logger) (*Controller, error) {
+	return &Controller{api: api, log: log}, nil
+}
+
+// Ensure is a no-op.  We only care about deletes.
+func (c Controller) Ensure(ctx context.Context, obj client.Object) error {
+	return nil
+}
+
+// Delete receives a k8s object that's been deleted and calls the StorageOS api
+// to remove it from management.
+func (c Controller) Delete(ctx context.Context, obj client.Object) error {
+	err := c.api.DeleteNamespace(obj.GetName())
+	if err != nil && err != storageos.ErrNodeNotFound {
+		return errors.Wrap(err, "re-queing operation")
 	}
+	c.log.Info("namespace decommissioned in storageos", "name", obj.GetName())
+	return nil
 }
 
-// SetupWithManager registers the controller with the controller manager.
-func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, workers int) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		WithOptions(controller.Options{MaxConcurrentReconciles: workers}).
-		For(&corev1.Namespace{}).
-		WithEventFilter(ChangePredicate{}).
-		Complete(r)
-}
-
-// Reconcile deletes the StorageOS namespace.  The delete will fail if there are
-// still volumes in the namespace.  Any errors will result in a requeue, with
-// standard back-off retries.
-//
-// Events are not sent as they require an object. By this point the namespace
-// object will no longer be available.
-func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	err := r.api.DeleteNamespace(req.Name)
-	if err != nil && err != storageos.ErrNamespaceNotFound {
-		// Re-queue without error.  We will get frequent transient errors, such
-		// as version conflicts or locked objects - that's ok.  Even refusal to
-		// delete due to remaining volumes should be seen as transient and
-		// should not raise an error.
-		return ctrl.Result{Requeue: true}, nil
-	}
-	return ctrl.Result{}, nil
-}
-
-// ChangePredicate filters events before enqueuing the keys.
-type ChangePredicate struct {
-	predicate.Funcs
-}
-
-// Create determines whether an object create should trigger a reconcile.
-func (ChangePredicate) Create(event.CreateEvent) bool {
-	return false
-}
-
-// Update determines whether an object update should trigger a reconcile.
-func (ChangePredicate) Update(event.UpdateEvent) bool {
-	return false
-}
-
-// Delete determines whether an object delete should trigger a reconcile.
-func (ChangePredicate) Delete(e event.DeleteEvent) bool {
-	return true
-}
-
-// Generic determines whether an generic event should trigger a reconcile.
-func (ChangePredicate) Generic(event.GenericEvent) bool {
-	return false
+// List returns a list of namespaces known to StorageOS, as NamespacedNames.
+// This is used for garbage collection and can be expensive. The garbage
+// collector is run in a separate goroutine periodically, not affecting the main
+// reconciliation control-loop.
+func (c Controller) List(ctx context.Context) ([]types.NamespacedName, error) {
+	return c.api.ListNamespaces()
 }

--- a/controllers/namespace-delete/predicate.go
+++ b/controllers/namespace-delete/predicate.go
@@ -1,0 +1,18 @@
+package nsdelete
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"github.com/storageos/api-manager/internal/pkg/predicate"
+)
+
+// Predicate filters events before enqueuing the keys.  Ignore all but Delete
+// events.
+type Predicate struct {
+	predicate.IgnoreFuncs
+}
+
+// Delete determines whether an object delete should trigger a reconcile.
+func (p Predicate) Delete(e event.DeleteEvent) bool {
+	return true
+}

--- a/controllers/namespace-delete/reconciler.go
+++ b/controllers/namespace-delete/reconciler.go
@@ -1,0 +1,65 @@
+package nsdelete
+
+import (
+	"fmt"
+	"time"
+
+	objectv1 "github.com/darkowlzz/operator-toolkit/controller/external-object-sync/v1"
+	"github.com/go-logr/logr"
+	"github.com/storageos/api-manager/internal/pkg/storageos"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+// Reconciler reconciles a Namespace object by deleting the StorageOS namespace
+// when the corresponding Kubernetes namespace is deleted.
+type Reconciler struct {
+	client.Client
+	log        logr.Logger
+	api        storageos.NamespaceDeleter
+	gcInterval time.Duration
+
+	objectv1.SyncReconciler
+}
+
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+
+// NewReconciler returns a new Namespace delete reconciler.
+//
+// The gcInterval determines how often the periodic resync operation should be
+// run.
+func NewReconciler(api storageos.NamespaceDeleter, k8s client.Client, gcInterval time.Duration) *Reconciler {
+	return &Reconciler{
+		Client:     k8s,
+		log:        ctrl.Log,
+		api:        api,
+		gcInterval: gcInterval,
+	}
+}
+
+// SetupWithManager registers the controller with the controller manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, workers int) error {
+	c, err := NewController(r.api, r.log)
+	if err != nil {
+		return err
+	}
+
+	// Initialize the reconciler.
+	err = r.SyncReconciler.Init(mgr, &corev1.Namespace{}, &corev1.NamespaceList{},
+		objectv1.WithName("ns-delete"),
+		objectv1.WithController(c),
+		objectv1.WithGarbageCollectionPeriod(r.gcInterval),
+		objectv1.WithLogger(r.log),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create new SyncReconciler: %w", err)
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: workers}).
+		For(&corev1.Namespace{}).
+		WithEventFilter(Predicate{}).
+		Complete(r)
+}

--- a/controllers/node-delete/README.md
+++ b/controllers/node-delete/README.md
@@ -46,7 +46,7 @@ request will be considered successful.
 ## Garbage Collection
 
 In case a node delete event was missed during a restart or outage, a garbage
-collection runs periodically.  It compares the list of nodes know to StorageOS,
+collection runs periodically.  It compares the list of nodes known to StorageOS,
 and removes any that are no longer known to Kubernetes.
 
 Garbage collection is run every hour by default (configurable via the

--- a/controllers/node-delete/controller.go
+++ b/controllers/node-delete/controller.go
@@ -37,7 +37,7 @@ func (c Controller) Ensure(ctx context.Context, obj client.Object) error {
 func (c Controller) Delete(ctx context.Context, obj client.Object) error {
 	err := c.api.DeleteNode(obj.GetName())
 	if err != nil && err != storageos.ErrNodeNotFound {
-		return errors.Wrap(err, "re-queing operation")
+		return errors.Wrap(err, "requeuing operation")
 	}
 	c.log.Info("node decommissioned in storageos", "name", obj.GetName())
 	return nil

--- a/internal/pkg/annotation/csi_driver.go
+++ b/internal/pkg/annotation/csi_driver.go
@@ -1,4 +1,4 @@
-// Package annotation contains helers for working with Kubernetes Annotations.
+// Package annotation contains helpers for working with Kubernetes Annotations.
 package annotation
 
 import (

--- a/internal/pkg/annotation/csi_driver_test.go
+++ b/internal/pkg/annotation/csi_driver_test.go
@@ -1,4 +1,4 @@
-// Package annotation contains helers for working with Kubernetes Annotations.
+// Package annotation contains helpers for working with Kubernetes Annotations.
 package annotation
 
 import (

--- a/internal/pkg/storageos/mock_client.go
+++ b/internal/pkg/storageos/mock_client.go
@@ -21,6 +21,7 @@ type MockClient struct {
 	namespaces         map[string]struct{}
 	nodes              map[string]struct{}
 	mu                 sync.RWMutex
+	ListNamespacesErr  error
 	DeleteNamespaceErr error
 	ListNodesErr       error
 	DeleteNodeErr      error
@@ -37,6 +38,20 @@ func NewMockClient() *MockClient {
 		nodes:      make(map[string]struct{}),
 		mu:         sync.RWMutex{},
 	}
+}
+
+// ListNamespaces returns a list of StorageOS namespaces as NamespacedNames.
+func (c *MockClient) ListNamespaces() ([]types.NamespacedName, error) {
+	if c.ListNamespacesErr != nil {
+		return nil, c.ListNamespacesErr
+	}
+	nn := []types.NamespacedName{}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for name := range c.namespaces {
+		nn = append(nn, types.NamespacedName{Name: name})
+	}
+	return nn, nil
 }
 
 // AddNamespace adds a namespace to the StorageOS cluster.
@@ -180,6 +195,7 @@ func (c *MockClient) Reset() {
 	c.vols = make(map[string]*SharedVolume)
 	c.namespaces = make(map[string]struct{})
 	c.nodes = make(map[string]struct{})
+	c.ListNamespacesErr = nil
 	c.DeleteNamespaceErr = nil
 	c.ListNodesErr = nil
 	c.DeleteNodeErr = nil

--- a/internal/pkg/storageos/mocks/mock_namespace_deleter.go
+++ b/internal/pkg/storageos/mocks/mock_namespace_deleter.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	types "k8s.io/apimachinery/pkg/types"
 	reflect "reflect"
 )
 
@@ -44,4 +45,19 @@ func (m *MockNamespaceDeleter) DeleteNamespace(arg0 string) error {
 func (mr *MockNamespaceDeleterMockRecorder) DeleteNamespace(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespace", reflect.TypeOf((*MockNamespaceDeleter)(nil).DeleteNamespace), arg0)
+}
+
+// ListNamespaces mocks base method
+func (m *MockNamespaceDeleter) ListNamespaces() ([]types.NamespacedName, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNamespaces")
+	ret0, _ := ret[0].([]types.NamespacedName)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNamespaces indicates an expected call of ListNamespaces
+func (mr *MockNamespaceDeleterMockRecorder) ListNamespaces() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaces", reflect.TypeOf((*MockNamespaceDeleter)(nil).ListNamespaces))
 }

--- a/main.go
+++ b/main.go
@@ -67,9 +67,10 @@ func main() {
 	var cacheExpiryInterval time.Duration
 	var k8sCreatePollInterval time.Duration
 	var k8sCreateWaitDuration time.Duration
+	var gcNamespaceDeleteInterval time.Duration
 	var gcNodeDeleteInterval time.Duration
-	var nodeDeleteWorkers int
 	var nsDeleteWorkers int
+	var nodeDeleteWorkers int
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
@@ -82,6 +83,7 @@ func main() {
 	flag.DurationVar(&cacheExpiryInterval, "cache-expiry-interval", time.Minute, "Frequency of cached volume re-validation.")
 	flag.DurationVar(&k8sCreatePollInterval, "k8s-create-poll-interval", 1*time.Second, "Frequency of Kubernetes api polling for new objects to appear once created.")
 	flag.DurationVar(&k8sCreateWaitDuration, "k8s-create-wait-duration", 20*time.Second, "Maximum time to wait for new Kubernetes objects to appear.")
+	flag.DurationVar(&gcNamespaceDeleteInterval, "namespace-delete-gc-interval", 1*time.Hour, "Frequency of node garbage collection.")
 	flag.DurationVar(&gcNodeDeleteInterval, "node-delete-gc-interval", 1*time.Hour, "Frequency of node garbage collection.")
 	flag.IntVar(&nodeDeleteWorkers, "node-delete-workers", 5, "Maximum concurrent node delete operations.")
 	flag.IntVar(&nsDeleteWorkers, "namespace-delete-workers", 5, "Maximum concurrent namespace delete operations.")
@@ -195,7 +197,7 @@ func main() {
 		errCh <- fmt.Errorf("node delete reconciler error: %w", err)
 	}
 	setupLog.Info("starting namespace delete controller ")
-	if err := nsdelete.NewReconciler(api, mgr.GetClient()).SetupWithManager(mgr, nsDeleteWorkers); err != nil {
+	if err := nsdelete.NewReconciler(api, mgr.GetClient(), gcNamespaceDeleteInterval).SetupWithManager(mgr, nsDeleteWorkers); err != nil {
 		errCh <- fmt.Errorf("namespace delete reconciler error: %w", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func main() {
 	flag.DurationVar(&cacheExpiryInterval, "cache-expiry-interval", time.Minute, "Frequency of cached volume re-validation.")
 	flag.DurationVar(&k8sCreatePollInterval, "k8s-create-poll-interval", 1*time.Second, "Frequency of Kubernetes api polling for new objects to appear once created.")
 	flag.DurationVar(&k8sCreateWaitDuration, "k8s-create-wait-duration", 20*time.Second, "Maximum time to wait for new Kubernetes objects to appear.")
-	flag.DurationVar(&gcNamespaceDeleteInterval, "namespace-delete-gc-interval", 1*time.Hour, "Frequency of node garbage collection.")
+	flag.DurationVar(&gcNamespaceDeleteInterval, "namespace-delete-gc-interval", 1*time.Hour, "Frequency of namespace garbage collection.")
 	flag.DurationVar(&gcNodeDeleteInterval, "node-delete-gc-interval", 1*time.Hour, "Frequency of node garbage collection.")
 	flag.IntVar(&nodeDeleteWorkers, "node-delete-workers", 5, "Maximum concurrent node delete operations.")
 	flag.IntVar(&nsDeleteWorkers, "namespace-delete-workers", 5, "Maximum concurrent namespace delete operations.")


### PR DESCRIPTION
Updates the namespace delete controller to use the operator toolkit, and adds garbage collection every 1h by default.