### PR TITLE
RFC3339Nano timestamps and flags to configure level & format

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,15 @@ The following flags are supported:
   -node-delete-gc-interval duration
     	Frequency of node garbage collection. (default 1h0m0s)
   -node-delete-workers int
-    	Maximum concurrent node delete operations. (default 5)   
+    	Maximum concurrent node delete operations. (default 5)
+  -zap-devel
+    	Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error)
+  -zap-encoder value
+    	Zap log encoding (one of 'json' or 'console')
+  -zap-log-level value
+    	Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
+  -zap-stacktrace-level value
+    	Zap Level at and above which stacktraces are captured (one of 'info', 'error').
 ```
 
 ## Setup/Development


### PR DESCRIPTION
Sets timestamps to use RFC3339Nano format, and adds command-line flags to configure log level and format.

Currently the `-zap-stacktrace-level` is hardcoded to `panic` to avoid stacktraces in the logs for errors that we recover from.  https://github.com/kubernetes-sigs/controller-runtime/pull/1348 addresses this.

Previous log entry:
```
{"level":"info","ts":1611140462.7687058,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":":8080"}
```
New default:
```
{"level":"info","timestamp":"2021-01-20T15:47:44.042084444Z,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":":8080"}
```