### PR TITLE
Pass context to api consistently

### DIFF
--- a/controllers/namespace-delete/controller.go
+++ b/controllers/namespace-delete/controller.go
@@ -36,7 +36,10 @@ func (c Controller) Ensure(ctx context.Context, obj client.Object) error {
 // Delete receives a k8s object that's been deleted and calls the StorageOS api
 // to remove it from management.
 func (c Controller) Delete(ctx context.Context, obj client.Object) error {
-	err := c.api.DeleteNamespace(obj.GetName())
+	ctx, cancel := context.WithTimeout(ctx, storageos.DefaultRequestTimeout)
+	defer cancel()
+
+	err := c.api.DeleteNamespace(ctx, obj.GetName())
 	if err != nil && err != storageos.ErrNamespaceNotFound {
 		return errors.Wrap(err, "requeuing operation")
 	}
@@ -49,5 +52,8 @@ func (c Controller) Delete(ctx context.Context, obj client.Object) error {
 // collector is run in a separate goroutine periodically, not affecting the main
 // reconciliation control-loop.
 func (c Controller) List(ctx context.Context) ([]types.NamespacedName, error) {
-	return c.api.ListNamespaces()
+	ctx, cancel := context.WithTimeout(ctx, storageos.DefaultRequestTimeout)
+	defer cancel()
+
+	return c.api.ListNamespaces(ctx)
 }

--- a/controllers/node-delete/controller.go
+++ b/controllers/node-delete/controller.go
@@ -35,7 +35,10 @@ func (c Controller) Ensure(ctx context.Context, obj client.Object) error {
 // Delete receives a k8s object that's been deleted and calls the StorageOS api
 // to remove it from management.
 func (c Controller) Delete(ctx context.Context, obj client.Object) error {
-	err := c.api.DeleteNode(obj.GetName())
+	ctx, cancel := context.WithTimeout(ctx, storageos.DefaultRequestTimeout)
+	defer cancel()
+
+	err := c.api.DeleteNode(ctx, obj.GetName())
 	if err != nil && err != storageos.ErrNodeNotFound {
 		return errors.Wrap(err, "requeuing operation")
 	}
@@ -48,5 +51,8 @@ func (c Controller) Delete(ctx context.Context, obj client.Object) error {
 // run in a separate goroutine periodically, not affecting the main
 // reconciliation control-loop.
 func (c Controller) List(ctx context.Context) ([]types.NamespacedName, error) {
-	return c.api.NodeNamespacedNames()
+	ctx, cancel := context.WithTimeout(ctx, storageos.DefaultRequestTimeout)
+	defer cancel()
+
+	return c.api.NodeNamespacedNames(ctx)
 }

--- a/internal/controllers/sharedvolume/controller.go
+++ b/internal/controllers/sharedvolume/controller.go
@@ -77,7 +77,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, apiPollInterval, cacheExpiry
 		start := time.Now()
 
 		// Query shared volumes info.
-		volumes, err := r.api.ListSharedVolumes()
+		volumes, err := r.api.ListSharedVolumes(ctx)
 		if err != nil {
 			r.log.Error(err, "failed to list shared volumes")
 			r.apiReset <- struct{}{}
@@ -127,7 +127,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, apiPollInterval, cacheExpiry
 			}
 
 			if externalEndpoint != vol.ExternalEndpoint {
-				if err := r.api.SetExternalEndpoint(vol.ID, vol.Namespace, externalEndpoint); err != nil {
+				if err := r.api.SetExternalEndpoint(ctx, vol.ID, vol.Namespace, externalEndpoint); err != nil {
 					log.Error(err, "shared volume external endpoint update failed")
 					continue
 				}

--- a/internal/controllers/sharedvolume/controller_test.go
+++ b/internal/controllers/sharedvolume/controller_test.go
@@ -376,7 +376,7 @@ func TestReconcile(t *testing.T) {
 					t.Errorf("SharedVolume.Reconcile() cache got:\n%v\n, want:\n%v", got, wnt)
 				}
 			}
-			got, err := r.api.ListSharedVolumes()
+			got, err := r.api.ListSharedVolumes(ctx)
 			if err != nil {
 				t.Errorf("SharedVolume.ListSharedVolumes() error: %v", err)
 			}

--- a/internal/pkg/storageos/mock_client.go
+++ b/internal/pkg/storageos/mock_client.go
@@ -79,7 +79,7 @@ func NewMockClient() *MockClient {
 }
 
 // ListNamespaces returns a list of StorageOS namespaces as NamespacedNames.
-func (c *MockClient) ListNamespaces() ([]types.NamespacedName, error) {
+func (c *MockClient) ListNamespaces(ctx context.Context) ([]types.NamespacedName, error) {
 	if c.ListNamespacesErr != nil {
 		return nil, c.ListNamespacesErr
 	}
@@ -111,7 +111,7 @@ func (c *MockClient) NamespaceExists(name string) bool {
 }
 
 // DeleteNamespace removes a namespace from the StorageOS cluster.
-func (c *MockClient) DeleteNamespace(name string) error {
+func (c *MockClient) DeleteNamespace(ctx context.Context, name string) error {
 	c.DeleteNamespaceCallCount[name]++
 	if c.DeleteNamespaceErr != nil {
 		return c.DeleteNamespaceErr
@@ -136,7 +136,7 @@ func (c *MockClient) NodeObjects(ctx context.Context) (map[string]Object, error)
 }
 
 // NodeNamespacedNames returns a list of StorageOS nodes as NamespacedNames.
-func (c *MockClient) NodeNamespacedNames() ([]types.NamespacedName, error) {
+func (c *MockClient) NodeNamespacedNames(ctx context.Context) ([]types.NamespacedName, error) {
 	if c.ListNodesErr != nil {
 		return nil, c.ListNodesErr
 	}
@@ -168,7 +168,7 @@ func (c *MockClient) NodeExists(name string) bool {
 }
 
 // DeleteNode removes a node from the StorageOS cluster.
-func (c *MockClient) DeleteNode(name string) error {
+func (c *MockClient) DeleteNode(ctx context.Context, name string) error {
 	c.DeleteNodeCallCount[name]++
 	if c.DeleteNodeErr != nil {
 		return c.DeleteNodeErr
@@ -219,7 +219,7 @@ func (c *MockClient) GetNodeLabels(name string) (map[string]string, error) {
 }
 
 // ListSharedVolumes returns a list of active shared volumes.
-func (c *MockClient) ListSharedVolumes() (SharedVolumeList, error) {
+func (c *MockClient) ListSharedVolumes(ctx context.Context) (SharedVolumeList, error) {
 	if c.SharedVolsErr != nil {
 		return nil, c.SharedVolsErr
 	}
@@ -234,7 +234,7 @@ func (c *MockClient) ListSharedVolumes() (SharedVolumeList, error) {
 
 // SetExternalEndpoint sets the external endpoint on a SharedVolume.  The
 // endpoint should be <host|ip>:<port>.
-func (c *MockClient) SetExternalEndpoint(id string, namespace string, endpoint string) error {
+func (c *MockClient) SetExternalEndpoint(ctx context.Context, id string, namespace string, endpoint string) error {
 	if c.SetEndpointErr != nil {
 		return c.SetEndpointErr
 	}

--- a/internal/pkg/storageos/mocks/mock_namespace_deleter.go
+++ b/internal/pkg/storageos/mocks/mock_namespace_deleter.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	types "k8s.io/apimachinery/pkg/types"
 	reflect "reflect"
@@ -34,30 +35,30 @@ func (m *MockNamespaceDeleter) EXPECT() *MockNamespaceDeleterMockRecorder {
 }
 
 // DeleteNamespace mocks base method
-func (m *MockNamespaceDeleter) DeleteNamespace(arg0 string) error {
+func (m *MockNamespaceDeleter) DeleteNamespace(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteNamespace", arg0)
+	ret := m.ctrl.Call(m, "DeleteNamespace", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteNamespace indicates an expected call of DeleteNamespace
-func (mr *MockNamespaceDeleterMockRecorder) DeleteNamespace(arg0 interface{}) *gomock.Call {
+func (mr *MockNamespaceDeleterMockRecorder) DeleteNamespace(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespace", reflect.TypeOf((*MockNamespaceDeleter)(nil).DeleteNamespace), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespace", reflect.TypeOf((*MockNamespaceDeleter)(nil).DeleteNamespace), arg0, arg1)
 }
 
 // ListNamespaces mocks base method
-func (m *MockNamespaceDeleter) ListNamespaces() ([]types.NamespacedName, error) {
+func (m *MockNamespaceDeleter) ListNamespaces(arg0 context.Context) ([]types.NamespacedName, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNamespaces")
+	ret := m.ctrl.Call(m, "ListNamespaces", arg0)
 	ret0, _ := ret[0].([]types.NamespacedName)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListNamespaces indicates an expected call of ListNamespaces
-func (mr *MockNamespaceDeleterMockRecorder) ListNamespaces() *gomock.Call {
+func (mr *MockNamespaceDeleterMockRecorder) ListNamespaces(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaces", reflect.TypeOf((*MockNamespaceDeleter)(nil).ListNamespaces))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaces", reflect.TypeOf((*MockNamespaceDeleter)(nil).ListNamespaces), arg0)
 }

--- a/internal/pkg/storageos/mocks/mock_node_deleter.go
+++ b/internal/pkg/storageos/mocks/mock_node_deleter.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	types "k8s.io/apimachinery/pkg/types"
 	reflect "reflect"
@@ -34,30 +35,30 @@ func (m *MockNodeDeleter) EXPECT() *MockNodeDeleterMockRecorder {
 }
 
 // DeleteNode mocks base method
-func (m *MockNodeDeleter) DeleteNode(arg0 string) error {
+func (m *MockNodeDeleter) DeleteNode(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteNode", arg0)
+	ret := m.ctrl.Call(m, "DeleteNode", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteNode indicates an expected call of DeleteNode
-func (mr *MockNodeDeleterMockRecorder) DeleteNode(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeDeleterMockRecorder) DeleteNode(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockNodeDeleter)(nil).DeleteNode), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockNodeDeleter)(nil).DeleteNode), arg0, arg1)
 }
 
 // NodeNamespacedNames mocks base method
-func (m *MockNodeDeleter) NodeNamespacedNames() ([]types.NamespacedName, error) {
+func (m *MockNodeDeleter) NodeNamespacedNames(arg0 context.Context) ([]types.NamespacedName, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NodeNamespacedNames")
+	ret := m.ctrl.Call(m, "NodeNamespacedNames", arg0)
 	ret0, _ := ret[0].([]types.NamespacedName)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NodeNamespacedNames indicates an expected call of NodeNamespacedNames
-func (mr *MockNodeDeleterMockRecorder) NodeNamespacedNames() *gomock.Call {
+func (mr *MockNodeDeleterMockRecorder) NodeNamespacedNames(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodeNamespacedNames", reflect.TypeOf((*MockNodeDeleter)(nil).NodeNamespacedNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodeNamespacedNames", reflect.TypeOf((*MockNodeDeleter)(nil).NodeNamespacedNames), arg0)
 }

--- a/internal/pkg/storageos/mocks/mock_volume_sharer.go
+++ b/internal/pkg/storageos/mocks/mock_volume_sharer.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	storageos "github.com/storageos/api-manager/internal/pkg/storageos"
 	reflect "reflect"
@@ -34,30 +35,30 @@ func (m *MockVolumeSharer) EXPECT() *MockVolumeSharerMockRecorder {
 }
 
 // ListSharedVolumes mocks base method
-func (m *MockVolumeSharer) ListSharedVolumes() (storageos.SharedVolumeList, error) {
+func (m *MockVolumeSharer) ListSharedVolumes(arg0 context.Context) (storageos.SharedVolumeList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSharedVolumes")
+	ret := m.ctrl.Call(m, "ListSharedVolumes", arg0)
 	ret0, _ := ret[0].(storageos.SharedVolumeList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListSharedVolumes indicates an expected call of ListSharedVolumes
-func (mr *MockVolumeSharerMockRecorder) ListSharedVolumes() *gomock.Call {
+func (mr *MockVolumeSharerMockRecorder) ListSharedVolumes(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSharedVolumes", reflect.TypeOf((*MockVolumeSharer)(nil).ListSharedVolumes))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSharedVolumes", reflect.TypeOf((*MockVolumeSharer)(nil).ListSharedVolumes), arg0)
 }
 
 // SetExternalEndpoint mocks base method
-func (m *MockVolumeSharer) SetExternalEndpoint(arg0, arg1, arg2 string) error {
+func (m *MockVolumeSharer) SetExternalEndpoint(arg0 context.Context, arg1, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetExternalEndpoint", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetExternalEndpoint", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetExternalEndpoint indicates an expected call of SetExternalEndpoint
-func (mr *MockVolumeSharerMockRecorder) SetExternalEndpoint(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockVolumeSharerMockRecorder) SetExternalEndpoint(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExternalEndpoint", reflect.TypeOf((*MockVolumeSharer)(nil).SetExternalEndpoint), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExternalEndpoint", reflect.TypeOf((*MockVolumeSharer)(nil).SetExternalEndpoint), arg0, arg1, arg2, arg3)
 }

--- a/internal/pkg/storageos/namespace.go
+++ b/internal/pkg/storageos/namespace.go
@@ -24,12 +24,12 @@ var (
 //NamespaceDeleter provides access to removing namespaces from StorageOS.
 //go:generate mockgen -destination=mocks/mock_namespace_deleter.go -package=mocks . NamespaceDeleter
 type NamespaceDeleter interface {
-	DeleteNamespace(name string) error
-	ListNamespaces() ([]types.NamespacedName, error)
+	DeleteNamespace(ctx context.Context, name string) error
+	ListNamespaces(ctx context.Context) ([]types.NamespacedName, error)
 }
 
 // ListNamespaces returns a list of all StorageOS namespace objects.
-func (c *Client) ListNamespaces() ([]types.NamespacedName, error) {
+func (c *Client) ListNamespaces(ctx context.Context) ([]types.NamespacedName, error) {
 	funcName := "list_namespaces"
 	start := time.Now()
 	defer func() {
@@ -40,8 +40,7 @@ func (c *Client) ListNamespaces() ([]types.NamespacedName, error) {
 		return e
 	}
 
-	ctx, cancel := context.WithTimeout(c.ctx, DefaultRequestTimeout)
-	defer cancel()
+	ctx = c.AddToken(ctx)
 
 	namespaces, _, err := c.api.ListNamespaces(ctx)
 	if err != nil {
@@ -56,7 +55,7 @@ func (c *Client) ListNamespaces() ([]types.NamespacedName, error) {
 
 // DeleteNamespace removes a namespace from the StorageOS cluster.  Delete will fail if
 // pre-requisites are not met (i.e. namespace has volumes).
-func (c *Client) DeleteNamespace(name string) error {
+func (c *Client) DeleteNamespace(ctx context.Context, name string) error {
 	funcName := "delete_namespace"
 	start := time.Now()
 	defer func() {
@@ -67,8 +66,7 @@ func (c *Client) DeleteNamespace(name string) error {
 		return e
 	}
 
-	ctx, cancel := context.WithTimeout(c.ctx, DefaultRequestTimeout)
-	defer cancel()
+	ctx = c.AddToken(ctx)
 
 	ns, err := c.getNamespaceByName(ctx, name)
 	if err != nil {

--- a/internal/pkg/storageos/shared_volume.go
+++ b/internal/pkg/storageos/shared_volume.go
@@ -38,12 +38,12 @@ var (
 // VolumeSharer provides access to StorageOS SharedVolumes.
 //go:generate mockgen -destination=mocks/mock_volume_sharer.go -package=mocks . VolumeSharer
 type VolumeSharer interface {
-	ListSharedVolumes() (SharedVolumeList, error)
-	SetExternalEndpoint(id string, namespace string, endpoint string) error
+	ListSharedVolumes(ctx context.Context) (SharedVolumeList, error)
+	SetExternalEndpoint(ctx context.Context, id string, namespace string, endpoint string) error
 }
 
 // ListSharedVolumes returns a list of active shared volumes.
-func (c *Client) ListSharedVolumes() (SharedVolumeList, error) {
+func (c *Client) ListSharedVolumes(ctx context.Context) (SharedVolumeList, error) {
 	funcName := "list_shared_volumes"
 	start := time.Now()
 	defer func() {
@@ -54,8 +54,7 @@ func (c *Client) ListSharedVolumes() (SharedVolumeList, error) {
 		return e
 	}
 
-	ctx, cancel := context.WithTimeout(c.ctx, DefaultRequestTimeout)
-	defer cancel()
+	ctx = c.AddToken(ctx)
 
 	namespaces, _, err := c.api.ListNamespaces(ctx)
 	if err != nil {
@@ -122,7 +121,7 @@ func toSharedVolume(namespace string, vol api.Volume) (*SharedVolume, error) {
 
 // SetExternalEndpoint sets the external endpoint on a SharedVolume.  The
 // endpoint should be <host|ip>:<port>.
-func (c *Client) SetExternalEndpoint(id string, namespace string, endpoint string) error {
+func (c *Client) SetExternalEndpoint(ctx context.Context, id string, namespace string, endpoint string) error {
 	funcName := "set_external_endpoint"
 	start := time.Now()
 	defer func() {
@@ -133,8 +132,7 @@ func (c *Client) SetExternalEndpoint(id string, namespace string, endpoint strin
 		return e
 	}
 
-	ctx, cancel := context.WithTimeout(c.ctx, DefaultRequestTimeout)
-	defer cancel()
+	ctx = c.AddToken(ctx)
 
 	curVol, err := c.getVolume(ctx, id, namespace)
 	if err != nil {


### PR DESCRIPTION
*Review after https://github.com/storageos/api-manager/pull/22 merges, or only review last commit*

This updates the remaining API function signatures to accept a context, add the auth token and pass to the API client, allowing the caller to set a timeout or cancel the context.