### PR TITLE
Run resync on startup after a configurable delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,18 +93,26 @@ The following flags are supported:
     	Paths to a kubeconfig. Only required if out-of-cluster.
   -metrics-addr string
     	The address the metric endpoint binds to. (default ":8080")
+  -namespace-delete-gc-delay duration
+    	Startup delay of initial namespace garbage collection. (default 20s)
   -namespace-delete-gc-interval duration
     	Frequency of namespace garbage collection. (default 1h0m0s)
   -namespace-delete-workers int
     	Maximum concurrent namespace delete operations. (default 5)
+  -node-delete-gc-delay duration
+    	Startup delay of initial node garbage collection. (default 30s)
   -node-delete-gc-interval duration
     	Frequency of node garbage collection. (default 1h0m0s)
   -node-delete-workers int
     	Maximum concurrent node delete operations. (default 5)
+  -node-label-resync-delay duration
+    	Startup delay of initial node label resync. (default 10s)
   -node-label-resync-interval duration
     	Frequency of node label resync. (default 1h0m0s)
   -node-label-sync-workers int
     	Maximum concurrent node label sync operations. (default 5)
+  -pvc-label-resync-delay duration
+    	Startup delay of initial PVC label resync. (default 5s)
   -pvc-label-resync-interval duration
     	Frequency of PVC label resync. (default 1h0m0s)
   -pvc-label-sync-workers int

--- a/controllers/namespace-delete/README.md
+++ b/controllers/namespace-delete/README.md
@@ -41,4 +41,8 @@ garbage collection runs periodically.  It compares the list of namespaces known
 to StorageOS, and removes any that are no longer known to Kubernetes.
 
 Garbage collection is run every hour by default (configurable via the
-`-namespace-delete-gc-interval` flag).
+`-namespace-delete-gc-interval` flag).  It can be disabled by setting
+`-namespace-delete-gc-interval` to `0s`.
+
+Garbage collection is run on startup after a delay defined by the
+`-namespace-delete-gc-delay` flag.

--- a/controllers/namespace_delete_test.go
+++ b/controllers/namespace_delete_test.go
@@ -16,14 +16,9 @@ import (
 	"github.com/storageos/api-manager/internal/pkg/storageos"
 )
 
-const (
-	nsDeleteTestWorkers              = 1
-	defaultNamespaceDeleteGCInterval = time.Hour // Don't let gc run by default.
-)
-
 // SetupNamespaceDeleteTest will set up a testing environment.  It must be
 // called from each test.
-func SetupNamespaceDeleteTest(ctx context.Context, createK8sNamespace bool, gcInterval time.Duration) *corev1.Namespace {
+func SetupNamespaceDeleteTest(ctx context.Context, createK8sNamespace bool, gcEnabled bool) *corev1.Namespace {
 	ns := &corev1.Namespace{}
 
 	var cancel func()
@@ -47,8 +42,13 @@ func SetupNamespaceDeleteTest(ctx context.Context, createK8sNamespace bool, gcIn
 		mgr, err := ctrl.NewManager(cfg, ctrl.Options{})
 		Expect(err).NotTo(HaveOccurred(), "failed to create manager")
 
-		controller := nsdelete.NewReconciler(api, mgr.GetClient(), gcInterval)
-		err = controller.SetupWithManager(mgr, nsDeleteTestWorkers)
+		gcInterval := defaultSyncInterval
+		if gcEnabled {
+			gcInterval = time.Hour
+		}
+
+		controller := nsdelete.NewReconciler(api, mgr.GetClient(), defaultSyncDelay, gcInterval)
+		err = controller.SetupWithManager(mgr, defaultWorkers)
 		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
 
 		go func() {
@@ -81,7 +81,7 @@ var _ = Describe("Namespace Delete controller", func() {
 	ctx := context.Background()
 
 	Context("When deleting a k8s Namespace", func() {
-		ns := SetupNamespaceDeleteTest(ctx, true, defaultNamespaceDeleteGCInterval)
+		ns := SetupNamespaceDeleteTest(ctx, true, false)
 		It("Should delete the StorageOS Namespace", func() {
 			// Skip test if running in envtest.  envtest doesn't handle namespace
 			// deletion in the same way as other objects, so the delete event is never
@@ -101,7 +101,7 @@ var _ = Describe("Namespace Delete controller", func() {
 	})
 
 	Context("When deleting a k8s Namespace and the StorageOS Namespace has already been deleted", func() {
-		ns := SetupNamespaceDeleteTest(ctx, true, defaultNamespaceDeleteGCInterval)
+		ns := SetupNamespaceDeleteTest(ctx, true, false)
 		It("Should not fail", func() {
 			// Skip test if running in envtest.  envtest doesn't handle namespace
 			// deletion in the same way as other objects, so the delete event is never
@@ -127,7 +127,7 @@ var _ = Describe("Namespace Delete controller", func() {
 	})
 
 	Context("When deleting a k8s Namespace that still has volumes", func() {
-		ns := SetupNamespaceDeleteTest(ctx, true, defaultNamespaceDeleteGCInterval)
+		ns := SetupNamespaceDeleteTest(ctx, true, false)
 		It("Should not delete the StorageOS Namespace", func() {
 			// Skip test if running in envtest.  envtest doesn't handle namespace
 			// deletion in the same way as other objects, so the delete event is never
@@ -155,7 +155,7 @@ var _ = Describe("Namespace Delete controller", func() {
 	})
 
 	Context("When starting after a k8s Namespace has been deleted but is still in StorageOS", func() {
-		ns := SetupNamespaceDeleteTest(ctx, false, 1*time.Second)
+		ns := SetupNamespaceDeleteTest(ctx, false, true)
 		It("The garbage collector should delete the StorageOS Namespace", func() {
 			By("Expecting StorageOS Namespace to be deleted")
 			Eventually(func() bool {

--- a/controllers/node-delete/README.md
+++ b/controllers/node-delete/README.md
@@ -50,4 +50,8 @@ collection runs periodically.  It compares the list of nodes known to StorageOS,
 and removes any that are no longer known to Kubernetes.
 
 Garbage collection is run every hour by default (configurable via the
-`-node-delete-gc-interval` flag).
+`-node-delete-gc-interval` flag).  It can be disabled by setting
+`-node-delete-gc-interval` to `0s`.
+
+Garbage collection is run on startup after a delay defined by the
+`-node-delete-gc-delay` flag.

--- a/controllers/node-delete/reconciler.go
+++ b/controllers/node-delete/reconciler.go
@@ -21,6 +21,7 @@ type Reconciler struct {
 	client.Client
 	log        logr.Logger
 	api        storageos.NodeDeleter
+	gcDelay    time.Duration
 	gcInterval time.Duration
 
 	objectv1.Reconciler
@@ -32,11 +33,12 @@ type Reconciler struct {
 //
 // The gcInterval determines how often the periodic resync operation should be
 // run.
-func NewReconciler(api storageos.NodeDeleter, k8s client.Client, gcInterval time.Duration) *Reconciler {
+func NewReconciler(api storageos.NodeDeleter, k8s client.Client, gcDelay time.Duration, gcInterval time.Duration) *Reconciler {
 	return &Reconciler{
 		Client:     k8s,
 		log:        ctrl.Log,
 		api:        api,
+		gcDelay:    gcDelay,
 		gcInterval: gcInterval,
 	}
 }
@@ -49,12 +51,12 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, workers int) error {
 	}
 
 	// Set the garbage collection interval.
+	r.Reconciler.SetStartupGarbageCollectionDelay(r.gcDelay)
 	r.Reconciler.SetGarbageCollectionPeriod(r.gcInterval)
 
 	// Initialize the reconciler.
-	err = r.Reconciler.Init(mgr, &corev1.Node{}, &corev1.NodeList{},
+	err = r.Reconciler.Init(mgr, c, &corev1.Node{}, &corev1.NodeList{},
 		syncv1.WithName("node-delete"),
-		syncv1.WithController(c),
 		syncv1.WithLogger(r.log),
 	)
 	if err != nil {

--- a/controllers/node-label/README.md
+++ b/controllers/node-label/README.md
@@ -48,4 +48,8 @@ resync runs periodically.  It re-applies the set of Kubernetes node labels to
 StorageOS nodes.
 
 Node label resync is run every hour by default (configurable via the
-`--node-label-resync-interval` flag).
+`-node-label-resync-interval` flag).  It can be disabled by setting
+`-node-label-resync-interval` to `0s`.
+
+Resync is run on startup after a delay defined by the
+`-node-label-resync-delay` flag.

--- a/controllers/node-label/controller.go
+++ b/controllers/node-label/controller.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/storageos/api-manager/internal/pkg/storageos"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -77,9 +76,4 @@ func (c Controller) Diff(ctx context.Context, objs []client.Object) ([]client.Ob
 // Delete is a no-op.  The node-delete controller will handle deletes.
 func (c Controller) Delete(ctx context.Context, obj client.Object) error {
 	return nil
-}
-
-// List is a no-op.  The reconcile performs its own resync.
-func (c Controller) List(ctx context.Context) ([]types.NamespacedName, error) {
-	return nil, nil
 }

--- a/controllers/node-label/reconciler.go
+++ b/controllers/node-label/reconciler.go
@@ -29,6 +29,7 @@ type Reconciler struct {
 	client.Client
 	log            logr.Logger
 	api            NodeLabeller
+	resyncDelay    time.Duration
 	resyncInterval time.Duration
 
 	msyncv1.Reconciler
@@ -40,11 +41,12 @@ type Reconciler struct {
 //
 // The resyncInterval determines how often the periodic resync operation should
 // be run.
-func NewReconciler(api NodeLabeller, k8s client.Client, resyncInterval time.Duration) *Reconciler {
+func NewReconciler(api NodeLabeller, k8s client.Client, resyncDelay time.Duration, resyncInterval time.Duration) *Reconciler {
 	return &Reconciler{
 		Client:         k8s,
 		log:            ctrl.Log,
 		api:            api,
+		resyncDelay:    resyncDelay,
 		resyncInterval: resyncInterval,
 	}
 }
@@ -57,6 +59,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, workers int) error {
 	}
 
 	// Set the resync interval.
+	r.Reconciler.SetStartupSyncDelay(r.resyncDelay)
 	r.Reconciler.SetResyncPeriod(r.resyncInterval)
 
 	// Initialize the reconciler.

--- a/controllers/node_label_sync_test.go
+++ b/controllers/node_label_sync_test.go
@@ -19,14 +19,9 @@ import (
 	"github.com/storageos/api-manager/internal/pkg/storageos"
 )
 
-const (
-	nodeLabelSyncTestWorkers       = 1
-	defaultNodeLabelResyncInterval = time.Hour // Don't let resync run by default.
-)
-
 // SetupNodeLabelSyncTest will set up a testing environment.  It must be
 // called from each test.
-func SetupNodeLabelSyncTest(ctx context.Context, isStorageOS bool, createLabels map[string]string, resyncInterval time.Duration) *corev1.Node {
+func SetupNodeLabelSyncTest(ctx context.Context, isStorageOS bool, createLabels map[string]string, gcEnabled bool) *corev1.Node {
 	node := &corev1.Node{}
 
 	var cancel func()
@@ -58,8 +53,13 @@ func SetupNodeLabelSyncTest(ctx context.Context, isStorageOS bool, createLabels 
 		mgr, err := ctrl.NewManager(cfg, ctrl.Options{})
 		Expect(err).NotTo(HaveOccurred(), "failed to create manager")
 
-		controller := nodelabel.NewReconciler(api, mgr.GetClient(), resyncInterval)
-		err = controller.SetupWithManager(mgr, nodeLabelSyncTestWorkers)
+		gcInterval := defaultSyncInterval
+		if gcEnabled {
+			gcInterval = time.Hour
+		}
+
+		controller := nodelabel.NewReconciler(api, mgr.GetClient(), defaultSyncDelay, gcInterval)
+		err = controller.SetupWithManager(mgr, defaultWorkers)
 		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
 
 		go func() {
@@ -113,7 +113,7 @@ var _ = Describe("Node Label controller", func() {
 	ctx := context.Background()
 
 	Context("When adding unreserved labels", func() {
-		node := SetupNodeLabelSyncTest(ctx, true, nil, defaultNodeLabelResyncInterval)
+		node := SetupNodeLabelSyncTest(ctx, true, nil, false)
 		It("Should sync labels to StorageOS Node", func() {
 			By("By adding unreserved labels to k8s Node")
 			node.SetLabels(unreservedLabels)
@@ -133,7 +133,7 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding reserved labels", func() {
-		node := SetupNodeLabelSyncTest(ctx, true, nil, defaultNodeLabelResyncInterval)
+		node := SetupNodeLabelSyncTest(ctx, true, nil, false)
 		It("Should sync labels to StorageOS Node", func() {
 			By("By adding reserved labels to k8s Node")
 			node.SetLabels(reservedLabels)
@@ -153,7 +153,7 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding mixed labels", func() {
-		node := SetupNodeLabelSyncTest(ctx, true, nil, defaultNodeLabelResyncInterval)
+		node := SetupNodeLabelSyncTest(ctx, true, nil, false)
 		It("Should sync labels to StorageOS Node", func() {
 			By("By adding mixed labels to k8s Node")
 			node.SetLabels(mixedLabels)
@@ -173,7 +173,7 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding unrecognised reserved labels", func() {
-		node := SetupNodeLabelSyncTest(ctx, true, nil, defaultNodeLabelResyncInterval)
+		node := SetupNodeLabelSyncTest(ctx, true, nil, false)
 		It("Should only sync recognised labels to StorageOS Node", func() {
 			By("By adding unrecognised reserved labels to k8s Node")
 			labels := map[string]string{}
@@ -198,7 +198,7 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding computeonly label", func() {
-		node := SetupNodeLabelSyncTest(ctx, true, nil, defaultNodeLabelResyncInterval)
+		node := SetupNodeLabelSyncTest(ctx, true, nil, false)
 		It("Should sync labels to StorageOS Node", func() {
 			By("By adding computeonly label to k8s Node")
 			labels := map[string]string{
@@ -221,7 +221,7 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding and removing mixed labels", func() {
-		node := SetupNodeLabelSyncTest(ctx, true, nil, defaultNodeLabelResyncInterval)
+		node := SetupNodeLabelSyncTest(ctx, true, nil, false)
 		It("Should sync labels to StorageOS Node", func() {
 			By("By adding labels to k8s Node")
 			node.SetLabels(mixedLabels)
@@ -256,7 +256,7 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding computeonly label and the StorageOS API returns an error", func() {
-		node := SetupNodeLabelSyncTest(ctx, true, nil, defaultNodeLabelResyncInterval)
+		node := SetupNodeLabelSyncTest(ctx, true, nil, false)
 		It("Should not sync labels to StorageOS Node", func() {
 			By("Setting API to return error")
 			api.EnsureNodeLabelsErr = errors.New("fake error")
@@ -282,7 +282,7 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding labels on a k8s Node without the StorageOS driver registration", func() {
-		node := SetupNodeLabelSyncTest(ctx, false, nil, defaultNodeLabelResyncInterval)
+		node := SetupNodeLabelSyncTest(ctx, false, nil, false)
 		It("Should not sync labels to StorageOS Node", func() {
 			By("By adding labels to k8s Node")
 			node.SetLabels(unreservedLabels)
@@ -302,7 +302,7 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding labels a k8s Node with a malformed StorageOS driver registration", func() {
-		node := SetupNodeLabelSyncTest(ctx, false, nil, defaultNodeLabelResyncInterval)
+		node := SetupNodeLabelSyncTest(ctx, false, nil, false)
 		It("Should not sync labels to StorageOS Node", func() {
 			By("By setting an invalid annotation")
 			node.Annotations = map[string]string{
@@ -328,7 +328,7 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding the StorageOS driver registration to a node with existing labels", func() {
-		node := SetupNodeLabelSyncTest(ctx, false, mixedLabels, defaultNodeLabelResyncInterval)
+		node := SetupNodeLabelSyncTest(ctx, false, mixedLabels, false)
 		It("Should sync labels to StorageOS Node", func() {
 			By("Expecting StorageOS Node labels to be empty")
 			Consistently(func() map[string]string {
@@ -358,7 +358,7 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When starting after a k8s Node with labels has been created", func() {
-		node := SetupNodeLabelSyncTest(ctx, true, mixedLabels, 1*time.Second)
+		node := SetupNodeLabelSyncTest(ctx, true, mixedLabels, true)
 		It("The resync should update the StorageOS Node", func() {
 			By("Expecting StorageOS Node labels to match")
 			Eventually(func() map[string]string {

--- a/controllers/pvc-label/README.md
+++ b/controllers/pvc-label/README.md
@@ -61,7 +61,11 @@ resync runs periodically.  It re-applies the set of Kubernetes PVC labels to
 StorageOS volumes.
 
 PVC label resync is run every hour by default (configurable via the
-`--pvc-label-resync-interval` flag).
+`-pvc-label-resync-interval` flag).  It can be disabled by setting
+`-pvc-label-resync-interval` to `0s`.
+
+Resync is run on startup after a delay defined by the
+`-pvc-label-resync-delay` flag.
 
 [CSI Provisioner]: https://github.com/storageos/external-provisioner/tree/53f0949-patched
 [StorageOS Feature Labels]: https://docs.storageos.com/docs/reference/labels

--- a/controllers/pvc-label/controller.go
+++ b/controllers/pvc-label/controller.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/storageos/api-manager/internal/pkg/storageos"
@@ -99,9 +98,4 @@ func (c Controller) Diff(ctx context.Context, objs []client.Object) ([]client.Ob
 // Delete is a no-op.  Volume removal is handled via CSI.
 func (c Controller) Delete(ctx context.Context, obj client.Object) error {
 	return nil
-}
-
-// List is a no-op.  The reconcile performs its own resync.
-func (c Controller) List(ctx context.Context) ([]types.NamespacedName, error) {
-	return nil, nil
 }

--- a/controllers/pvc-label/reconciler.go
+++ b/controllers/pvc-label/reconciler.go
@@ -29,6 +29,7 @@ type Reconciler struct {
 	client.Client
 	log            logr.Logger
 	api            VolumeLabeller
+	resyncDelay    time.Duration
 	resyncInterval time.Duration
 
 	msyncv1.Reconciler
@@ -40,11 +41,12 @@ type Reconciler struct {
 //
 // The resyncInterval determines how often the periodic resync operation should
 // be run.
-func NewReconciler(api VolumeLabeller, k8s client.Client, resyncInterval time.Duration) *Reconciler {
+func NewReconciler(api VolumeLabeller, k8s client.Client, resyncDelay time.Duration, resyncInterval time.Duration) *Reconciler {
 	return &Reconciler{
 		Client:         k8s,
 		log:            ctrl.Log,
 		api:            api,
+		resyncDelay:    resyncDelay,
 		resyncInterval: resyncInterval,
 	}
 }
@@ -57,6 +59,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, workers int) error {
 	}
 
 	// Set the resync interval.
+	r.Reconciler.SetStartupSyncDelay(r.resyncDelay)
 	r.Reconciler.SetResyncPeriod(r.resyncInterval)
 
 	// Initialize the reconciler.

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -25,6 +25,17 @@ const (
 	// ready to process events.  The manager starts asychronously, so without a
 	// wait, events may be missed.
 	managerWaitDuration = 1 * time.Second
+
+	// defaultWorkers is the number of concurrent requests that test controllers
+	// can operate on in paralllel.
+	defaultWorkers = 1
+
+	// defaultSyncDelay sets the sync controller to run almost immediately.
+	defaultSyncDelay = 1 * time.Second
+
+	// defaultSyncInterval is set to zero to disable sync.  Tests should enable
+	// it when required.
+	defaultSyncInterval = time.Duration(0)
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/storageos/api-manager
 go 1.13
 
 require (
-	github.com/darkowlzz/operator-toolkit v0.0.0-20210119145329-cd50276d2a58
+	github.com/darkowlzz/operator-toolkit v0.0.0-20210127153629-3694257a34c2
 	github.com/go-logr/logr v0.3.0
 	github.com/golang/mock v1.4.4
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/darkowlzz/operator-toolkit v0.0.0-20210119145329-cd50276d2a58 h1:IfWfSfC15WSK/P9IN6Ga8p1wS6NabcdSdetQxXZUOCA=
-github.com/darkowlzz/operator-toolkit v0.0.0-20210119145329-cd50276d2a58/go.mod h1:lzhFkL8rRacWazlRR62eJDeQ6SWNR7udeAvHg8dR9V8=
+github.com/darkowlzz/operator-toolkit v0.0.0-20210127153629-3694257a34c2 h1:bquaU56gX7ExA/Z15yUeTMAtgWs745r3xyCK/wQ7DD4=
+github.com/darkowlzz/operator-toolkit v0.0.0-20210127153629-3694257a34c2/go.mod h1:lzhFkL8rRacWazlRR62eJDeQ6SWNR7udeAvHg8dR9V8=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/vendor/github.com/darkowlzz/operator-toolkit/controller/external-object-sync/v1/controller.go
+++ b/vendor/github.com/darkowlzz/operator-toolkit/controller/external-object-sync/v1/controller.go
@@ -1,0 +1,26 @@
+package v1
+
+//go:generate mockgen -destination=mocks/mock_controller.go -package=mocks github.com/darkowlzz/operator-toolkit/controller/external-object-sync/v1 Controller
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	syncv1 "github.com/darkowlzz/operator-toolkit/controller/sync/v1"
+)
+
+// Controller is an external object sync controller interface that must be
+// implemented by an external sync controller. It provides methods required for
+// reconciling and syncing a k8s object to external objects.
+type Controller interface {
+	syncv1.Controller
+
+	// List lists all the objects in the external system. It returns a list of
+	// NamespacedName of the external objects. This is used for garbage
+	// collection and can be expensive. The garbage collector is run in a
+	// separate goroutine periodically, not affecting the main reconciliation
+	// control-loop. If the external system has no concept of namespace, the
+	// namespace value can be empty.
+	List(context.Context) ([]types.NamespacedName, error)
+}

--- a/vendor/github.com/darkowlzz/operator-toolkit/controller/metadata-sync/v1/controller.go
+++ b/vendor/github.com/darkowlzz/operator-toolkit/controller/metadata-sync/v1/controller.go
@@ -5,30 +5,16 @@ package v1
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	syncv1 "github.com/darkowlzz/operator-toolkit/controller/sync/v1"
 )
 
 // Controller is a metadata sync controller interface that must be implemented
 // by an external sync controller. It provides methods required for reconciling
 // and syncing a k8s object's metadata to external objects.
 type Controller interface {
-	// EnsureMeta receives a k8s object and calls an external system's API to
-	// ensure that an associated object exists in the external system and that
-	// it has the desired metadata applied to it.
-	Ensure(context.Context, client.Object) error
-
-	// Delete receives a k8s object that's deleted and calls an external
-	// system's API to delete the associated object in the external system.
-	Delete(context.Context, client.Object) error
-
-	// List lists all the objects in the external system. It returns a list of
-	// NamespacedName of the external objects. This is used for garbage
-	// collection and can be expensive. The garbage collector is run in a
-	// separate goroutine periodically, not affecting the main reconciliation
-	// control-loop. If the external system has no concept of namespace, the
-	// namespace value can be empty.
-	List(context.Context) ([]types.NamespacedName, error)
+	syncv1.Controller
 
 	// Diff receives a list of k8s objects and should return a subset of the
 	// same list to indicate the objects that are not in sync with the external

--- a/vendor/github.com/darkowlzz/operator-toolkit/controller/sync/v1/controller.go
+++ b/vendor/github.com/darkowlzz/operator-toolkit/controller/sync/v1/controller.go
@@ -5,13 +5,12 @@ package v1
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Controller is an external object sync controller interface that must be
-// implemented by an external object sync controller. It provides methods
-// required for reconciling and syncing external objects.
+// Controller is an object sync controller interface that must be implemented
+// by an object sync controller. It provides methods required for reconciling
+// and syncing objects.
 type Controller interface {
 	// Ensure receives a k8s object and calls an external system's API to
 	// ensure an associated object exists in the external system. Based on the
@@ -22,12 +21,4 @@ type Controller interface {
 	// Delete receives a k8s object that's deleted and calls an external
 	// system's API to delete the associated object in the external system.
 	Delete(context.Context, client.Object) error
-
-	// List lists all the objects in the external system. It returns a list of
-	// NamespacedName of the external objects. This is used for garbage
-	// collection and can be expensive. The garbage collector is run in a
-	// separate goroutine periodically, not affecting the main reconciliation
-	// control-loop. If the external system has no concept of namespace, the
-	// namespace value can be empty.
-	List(context.Context) ([]types.NamespacedName, error)
 }

--- a/vendor/github.com/darkowlzz/operator-toolkit/controller/sync/v1/sync.go
+++ b/vendor/github.com/darkowlzz/operator-toolkit/controller/sync/v1/sync.go
@@ -1,8 +1,6 @@
 package v1
 
 import (
-	"fmt"
-
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -52,13 +50,6 @@ func WithLogger(log logr.Logger) ReconcilerOption {
 	}
 }
 
-// WithController sets the Controller in a Reconciler.
-func WithController(ctrlr Controller) ReconcilerOption {
-	return func(s *Reconciler) {
-		s.Ctrlr = ctrlr
-	}
-}
-
 // WithScheme sets the runtime Scheme of the Reconciler.
 func WithScheme(scheme *runtime.Scheme) ReconcilerOption {
 	return func(s *Reconciler) {
@@ -75,7 +66,9 @@ func WithSyncFuncs(sf []SyncFunc) ReconcilerOption {
 
 // Init initializes the Reconciler for a given Object with the given
 // options.
-func (s *Reconciler) Init(mgr ctrl.Manager, prototype client.Object, prototypeList client.ObjectList, opts ...ReconcilerOption) error {
+func (s *Reconciler) Init(mgr ctrl.Manager, ctrlr Controller, prototype client.Object, prototypeList client.ObjectList, opts ...ReconcilerOption) error {
+	s.Ctrlr = ctrlr
+
 	// Use manager if provided. This is helpful in tests to provide explicit
 	// client and scheme without a manager.
 	if mgr != nil {
@@ -102,11 +95,6 @@ func (s *Reconciler) Init(mgr ctrl.Manager, prototype client.Object, prototypeLi
 	// If a name is set, log it as the reconciler name.
 	if s.Name != "" {
 		s.Log = s.Log.WithValues("reconciler", s.Name)
-	}
-
-	// Perform validation.
-	if s.Ctrlr == nil {
-		return fmt.Errorf("must provide a Controller to the Reconciler")
 	}
 
 	// Run the sync functions.

--- a/vendor/github.com/darkowlzz/operator-toolkit/controller/sync/v1/syncfunc.go
+++ b/vendor/github.com/darkowlzz/operator-toolkit/controller/sync/v1/syncfunc.go
@@ -1,23 +1,50 @@
 package v1
 
-import "time"
+import (
+	"time"
+)
+
+const (
+	// defaultStartupSyncDelay is the default delay period before starting the
+	// sync ticker.
+	defaultStartupSyncDelay time.Duration = 10 * time.Second
+
+	zeroDuration time.Duration = 0 * time.Minute
+)
 
 // SyncFunc defines a sync function with a sync period.
 type SyncFunc struct {
-	f      func()
-	period time.Duration
+	f                func()
+	period           time.Duration
+	startupSyncDelay time.Duration
 }
 
 // NewSyncFunc returns a new SyncFunc, given a function and a sync period.
-func NewSyncFunc(f func(), p time.Duration) SyncFunc {
+func NewSyncFunc(f func(), p time.Duration, d time.Duration) SyncFunc {
+	// NOTE: This is not allowed to be set to zero to avoid running the sync
+	// before the controller has been fully initialized. It results in errors
+	// like: "the cache is not started, can not read objects".
+	if d == zeroDuration {
+		d = defaultStartupSyncDelay
+	}
+
 	return SyncFunc{
-		f:      f,
-		period: p,
+		f:                f,
+		period:           p,
+		startupSyncDelay: d,
 	}
 }
 
 // Run runs the SyncFunc function at the SyncFunc period.
 func (sf SyncFunc) Run() {
+	// Wait before starting the sync func.
+	time.Sleep(sf.startupSyncDelay)
+
+	// Run the sync function before starting a ticker based run.
+	sf.Call()
+
+	// Start a ticker with the given period at which the sync function is
+	// called.
 	ticker := time.NewTicker(sf.period)
 	defer ticker.Stop()
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ github.com/antihax/optional
 github.com/beorn7/perks/quantile
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
-# github.com/darkowlzz/operator-toolkit v0.0.0-20210119145329-cd50276d2a58
+# github.com/darkowlzz/operator-toolkit v0.0.0-20210127153629-3694257a34c2
 github.com/darkowlzz/operator-toolkit/controller/external-object-sync/v1
 github.com/darkowlzz/operator-toolkit/controller/metadata-sync/v1
 github.com/darkowlzz/operator-toolkit/controller/sync/v1


### PR DESCRIPTION
Adds flags to configure how long each controller should wait before doing a full resync/garbage collection.  These are set low by default so that they run almost immediately.