### PR TITLE
Log api reason

### DIFF
--- a/controllers/namespace-delete/controller.go
+++ b/controllers/namespace-delete/controller.go
@@ -5,7 +5,6 @@ import (
 
 	syncv1 "github.com/darkowlzz/operator-toolkit/controller/sync/v1"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -41,7 +40,7 @@ func (c Controller) Delete(ctx context.Context, obj client.Object) error {
 
 	err := c.api.DeleteNamespace(ctx, obj.GetName())
 	if err != nil && err != storageos.ErrNamespaceNotFound {
-		return errors.Wrap(err, "requeuing operation")
+		return err
 	}
 	c.log.Info("namespace decommissioned in storageos", "name", obj.GetName())
 	return nil

--- a/controllers/node-delete/controller.go
+++ b/controllers/node-delete/controller.go
@@ -5,7 +5,6 @@ import (
 
 	syncv1 "github.com/darkowlzz/operator-toolkit/controller/sync/v1"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -40,7 +39,7 @@ func (c Controller) Delete(ctx context.Context, obj client.Object) error {
 
 	err := c.api.DeleteNode(ctx, obj.GetName())
 	if err != nil && err != storageos.ErrNodeNotFound {
-		return errors.Wrap(err, "requeuing operation")
+		return err
 	}
 	c.log.Info("node decommissioned in storageos", "name", obj.GetName())
 	return nil

--- a/controllers/node-label/controller.go
+++ b/controllers/node-label/controller.go
@@ -6,7 +6,6 @@ import (
 
 	msyncv1 "github.com/darkowlzz/operator-toolkit/controller/metadata-sync/v1"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	"github.com/storageos/api-manager/internal/pkg/storageos"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -41,7 +40,7 @@ func (c Controller) Ensure(ctx context.Context, obj client.Object) error {
 	defer cancel()
 
 	if err := c.api.EnsureNodeLabels(ctx, obj.GetName(), obj.GetLabels()); err != nil {
-		return errors.Wrap(err, "requeuing operation")
+		return err
 	}
 	c.log.Info("node labels applied to storageos", "name", obj.GetName())
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
-	github.com/storageos/go-api/v2 v2.4.0-alpha7
+	github.com/storageos/go-api/v2 v2.3.1-0.20210129113721-89706365d21f
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/zap v1.15.0
 	k8s.io/api v0.19.2

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
-	github.com/storageos/go-api/v2 v2.4.0-alpha6
+	github.com/storageos/go-api/v2 v2.4.0-alpha7
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/zap v1.15.0
 	k8s.io/api v0.19.2

--- a/go.sum
+++ b/go.sum
@@ -577,8 +577,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
-github.com/storageos/go-api/v2 v2.4.0-alpha7 h1:kJxyJhP1WgmL92jGhC9eeiVSAoAfBX/KD/y2TFxTmp4=
-github.com/storageos/go-api/v2 v2.4.0-alpha7/go.mod h1:dYUrmW64GDiLtUSEyYkr0+OAJ5VgQjQ+Q7STYWDWY9g=
+github.com/storageos/go-api/v2 v2.3.1-0.20210129113721-89706365d21f h1:fKgVhj1/KXqYlUOSyvlY4izADXhkFN8ukA5P6kA42ko=
+github.com/storageos/go-api/v2 v2.3.1-0.20210129113721-89706365d21f/go.mod h1:dYUrmW64GDiLtUSEyYkr0+OAJ5VgQjQ+Q7STYWDWY9g=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=

--- a/go.sum
+++ b/go.sum
@@ -577,8 +577,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
-github.com/storageos/go-api/v2 v2.4.0-alpha6 h1:rmTHV1f69BRmEGK7zlvEVAZcA8+Erh+dj3v6W6qADRM=
-github.com/storageos/go-api/v2 v2.4.0-alpha6/go.mod h1:FpEkX+56ILt5L8Jt7pnXM1BRzFQ5YPkMSeZijTGcw5U=
+github.com/storageos/go-api/v2 v2.4.0-alpha7 h1:kJxyJhP1WgmL92jGhC9eeiVSAoAfBX/KD/y2TFxTmp4=
+github.com/storageos/go-api/v2 v2.4.0-alpha7/go.mod h1:dYUrmW64GDiLtUSEyYkr0+OAJ5VgQjQ+Q7STYWDWY9g=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=

--- a/internal/pkg/storageos/client.go
+++ b/internal/pkg/storageos/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -181,7 +180,7 @@ func Authenticate(client *api.APIClient, username, password string) (context.Con
 		Password: password,
 	})
 	if err != nil {
-		return nil, err
+		return nil, api.MapAPIError(err, resp)
 	}
 	defer resp.Body.Close()
 
@@ -210,7 +209,7 @@ func (c *Client) Refresh(ctx context.Context, secretPath, endpoint string, reset
 			if err != nil {
 				log.Info("failed to refresh storageos api credentials", "error", err)
 				if c.traced {
-					resultCounter.Increment("refresh_token", GetAPIErrorRootCause(err))
+					resultCounter.Increment("refresh_token", api.MapAPIError(err, resp))
 				}
 				continue
 			}
@@ -238,7 +237,7 @@ func (c *Client) Refresh(ctx context.Context, secretPath, endpoint string, reset
 			if err != nil {
 				log.Info("failed to recreate storageos api client", "error", err)
 				if c.traced {
-					resultCounter.Increment("reset_api", GetAPIErrorRootCause(err))
+					resultCounter.Increment("reset_api", err)
 				}
 				continue
 			}
@@ -281,50 +280,4 @@ func ReadCredsFromMountedSecret(path string) (string, string, error) {
 		return "", "", err
 	}
 	return username, password, nil
-}
-
-// GetAPIErrorResponse returns the actual API response error incl. the response
-// Body.
-func GetAPIErrorResponse(oerr error) error {
-	if n, ok := oerr.(api.GenericOpenAPIError); ok {
-		return fmt.Errorf("%s: %s", strings.TrimSuffix(n.Error(), "\n"), n.Body())
-	}
-	return oerr
-}
-
-// GetAPIErrorRootCause attempts to unwrap the error to isolate the root cause,
-// without decoration from the chain of calling functions.
-//
-// The list of error types evaluated is somewhat arbitrary: we want to capture
-// things like:
-//
-// - `connect: connection refused`
-// - `401 Unauthorized`
-//
-// But not:
-//
-//  - `Get http://storageos:5705/v2/namespaces: net/http: request canceled while
-//     waiting for connection (Client.Timeout exceeded while awaiting headers)`
-//
-// Some errors could be unwrapped even further, but after a certain level the
-// detail no longer makes sense.  This is purely subjective.
-//
-// Callers should not rely on specific errors being returned as they are subject
-// to fine-tuning.
-func GetAPIErrorRootCause(oerr error) error {
-	if uerr, ok := oerr.(*url.Error); ok {
-		uerrp := uerr.Unwrap()
-		if uerrp == nil {
-			return uerr
-		}
-		if nerr, ok := uerrp.(*net.OpError); ok {
-			nerrp := nerr.Unwrap()
-			if nerrp == nil {
-				return nerr
-			}
-			return nerrp
-		}
-		return uerrp
-	}
-	return oerr
 }

--- a/internal/pkg/storageos/error_format.go
+++ b/internal/pkg/storageos/error_format.go
@@ -9,7 +9,7 @@ import (
 // that occurred along with a list of the errors.
 func ListErrors(es []error) string {
 	if len(es) == 1 {
-		return fmt.Sprintf("1 error occurred: %s", es[0])
+		return es[0].Error()
 	}
 
 	points := make([]string, len(es))

--- a/internal/pkg/storageos/error_format.go
+++ b/internal/pkg/storageos/error_format.go
@@ -1,0 +1,21 @@
+package storageos
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ListErrors is a basic formatter that outputs the number of errors
+// that occurred along with a list of the errors.
+func ListErrors(es []error) string {
+	if len(es) == 1 {
+		return fmt.Sprintf("1 error occurred: %s", es[0])
+	}
+
+	points := make([]string, len(es))
+	for i, err := range es {
+		points[i] = err.Error()
+	}
+
+	return fmt.Sprintf("%d errors occurred: %s", len(es), strings.Join(points, ", "))
+}

--- a/internal/pkg/storageos/volume.go
+++ b/internal/pkg/storageos/volume.go
@@ -24,7 +24,7 @@ func (c *Client) VolumeObjects(ctx context.Context) (map[client.ObjectKey]Object
 		metrics.Latency.Observe(funcName, time.Since(start))
 	}()
 	observeErr := func(e error) error {
-		metrics.Errors.Increment(funcName, GetAPIErrorRootCause(e))
+		metrics.Errors.Increment(funcName, e)
 		return e
 	}
 
@@ -50,7 +50,7 @@ func (c *Client) ListVolumes(ctx context.Context) ([]Object, error) {
 		metrics.Latency.Observe(funcName, time.Since(start))
 	}()
 	observeErr := func(e error) error {
-		metrics.Errors.Increment(funcName, GetAPIErrorRootCause(e))
+		metrics.Errors.Increment(funcName, e)
 		return e
 	}
 
@@ -75,9 +75,9 @@ func (c *Client) getVolumes(ctx context.Context) ([]api.Volume, error) {
 		return nil, err
 	}
 	for _, ns := range namespaces {
-		nsVols, _, err := c.api.ListVolumes(ctx, ns.GetID())
+		nsVols, resp, err := c.api.ListVolumes(ctx, ns.GetID())
 		if err != nil {
-			return nil, err
+			return nil, api.MapAPIError(err, resp)
 		}
 		volumes = append(volumes, nsVols...)
 	}
@@ -91,9 +91,9 @@ func (c *Client) getVolumeByKey(ctx context.Context, key client.ObjectKey) (*api
 		return nil, err
 	}
 
-	volumes, _, err := c.api.ListVolumes(ctx, ns.Id)
+	volumes, resp, err := c.api.ListVolumes(ctx, ns.Id)
 	if err != nil {
-		return nil, err
+		return nil, api.MapAPIError(err, resp)
 	}
 	for _, vol := range volumes {
 		if vol.Name == key.Name {

--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func main() {
 			break
 		}
 		setupLog.Info(fmt.Sprintf("unable to connect to storageos api, retrying in %s", apiRetryInterval), "msg", err)
-		apimetrics.Errors.Increment("setup", storageos.GetAPIErrorRootCause(err))
+		apimetrics.Errors.Increment("setup", err)
 		time.Sleep(apiRetryInterval)
 	}
 	setupLog.V(1).Info("connected to the storageos api")

--- a/vendor/github.com/storageos/go-api/v2/Makefile
+++ b/vendor/github.com/storageos/go-api/v2/Makefile
@@ -56,5 +56,6 @@ customise:  ## Applies customisations to the generated API.
 	sed -i "s#module github.com/GIT_USER_ID/GIT_REPO_ID#module github.com/${GIT_USER_ID}/${GIT_REPO_ID}/v2#g" go.mod
 
 clean: ## Removes generated files.
-	rm -f .openapi-generator-ignore .gitignore git_push.sh .travis.yml *.go go.mod go.sum
-	rm -rf .openapi-generator/ api/ docs/
+	rm -f .openapi-generator-ignore .gitignore git_push.sh .travis.yml go.mod go.sum
+	rm -f  api_default.go client.go configuration.go model_*.go response.go
+	rm -rf .openapi-generator/ api/openapi.yaml docs/

--- a/vendor/github.com/storageos/go-api/v2/api/errors.go
+++ b/vendor/github.com/storageos/go-api/v2/api/errors.go
@@ -1,0 +1,198 @@
+package api
+
+import (
+	"fmt"
+)
+
+// AuthenticationError indicates that the requested operation could not be
+// performed for the client due to an issue with the authentication credentials
+// provided by the client.
+type AuthenticationError struct {
+	msg string
+}
+
+func (e AuthenticationError) Error() string {
+	if e.msg == "" {
+		return "authentication error"
+	}
+	return e.msg
+}
+
+// NewAuthenticationError returns a new AuthenticationError using msg as an
+// optional error message if given.
+func NewAuthenticationError(msg string) AuthenticationError {
+	return AuthenticationError{
+		msg: msg,
+	}
+}
+
+// UnauthorisedError indicates that the requested operation is disallowed
+// for the user which the client is authenticated as.
+type UnauthorisedError struct {
+	msg string
+}
+
+func (e UnauthorisedError) Error() string {
+	if e.msg == "" {
+		return "authenticated user is not authorised to perform that action"
+	}
+	return e.msg
+}
+
+// NewUnauthorisedError returns a new UnauthorisedError using msg as an
+// optional error message if given.
+func NewUnauthorisedError(msg string) UnauthorisedError {
+	return UnauthorisedError{
+		msg: msg,
+	}
+}
+
+// StaleWriteError indicates that the target resource for the requested
+// operation has been concurrently updated, invalidating the request. The client
+// should fetch the latest version of the resource before attempting to perform
+// another update.
+type StaleWriteError struct {
+	msg string
+}
+
+func (e StaleWriteError) Error() string {
+	if e.msg == "" {
+		return "stale write attempted"
+	}
+	return e.msg
+}
+
+// NewStaleWriteError returns a new StaleWriteError using msg as an optional
+// error message if given.
+func NewStaleWriteError(msg string) StaleWriteError {
+	return StaleWriteError{
+		msg: msg,
+	}
+}
+
+// InvalidStateTransitionError indicates that the requested operation cannot
+// be performed for the target resource in its current state.
+type InvalidStateTransitionError struct {
+	msg string
+}
+
+func (e InvalidStateTransitionError) Error() string {
+	if e.msg == "" {
+		return "target resource is in an invalid state for carrying out the request"
+	}
+	return e.msg
+}
+
+// NewInvalidStateTransitionError returns a new InvalidStateTransitionError
+// using msg as an optional error message if given.
+func NewInvalidStateTransitionError(msg string) InvalidStateTransitionError {
+	return InvalidStateTransitionError{
+		msg: msg,
+	}
+}
+
+// LockedError indicates that the requested operation cannot be performed
+// because a lock is held for the target resource.
+type LockedError struct {
+	msg string
+}
+
+func (e LockedError) Error() string {
+	if e.msg == "" {
+		return "requsted operation cannot be safely completed as the target resource is locked"
+	}
+	return e.msg
+}
+
+// NewLockedError returns a new LockedError using msg as an optional error
+// message if given.
+func NewLockedError(msg string) LockedError {
+	return LockedError{
+		msg: msg,
+	}
+}
+
+// LicenceCapabilityError indicates that the requested operation cannot be
+// carried out due to a licensing issue with the cluster.
+type LicenceCapabilityError struct {
+	msg string
+}
+
+func (e LicenceCapabilityError) Error() string {
+	if e.msg == "" {
+		return "licence capability error"
+	}
+	return e.msg
+}
+
+// NewLicenceCapabilityError returns a new LicenceCapabilityError using msg as
+// an optional error message if given.
+func NewLicenceCapabilityError(msg string) LicenceCapabilityError {
+	return LicenceCapabilityError{
+		msg: msg,
+	}
+}
+
+// ServerError indicates that an unrecoverable error occurred while attempting
+// to perform the requested operation.
+type ServerError struct {
+	msg string
+}
+
+func (e ServerError) Error() string {
+	if e.msg == "" {
+		return "server encountered internal error"
+	}
+	return e.msg
+}
+
+// NewServerError returns a new ServerError using msg as an optional error
+// message if given.
+func NewServerError(msg string) ServerError {
+	return ServerError{
+		msg: msg,
+	}
+}
+
+// StoreError indicates that the requested operation could not be performed due
+// to a store outage.
+type StoreError struct {
+	msg string
+}
+
+func (e StoreError) Error() string {
+	if e.msg == "" {
+		return "server encountered store outage"
+	}
+	return e.msg
+}
+
+// NewStoreError returns a new StoreError using msg as an optional error
+// message if given.
+func NewStoreError(msg string) StoreError {
+	return StoreError{
+		msg: msg,
+	}
+}
+
+// EncodingError provides a unified error type which transport encoding
+// implementations return when given a value that cannot be encoded with the
+// target encoding.
+type EncodingError struct {
+	err        error
+	targetType interface{}
+	value      interface{}
+}
+
+func (e EncodingError) Error() string {
+	return fmt.Sprintf("cannot encode %v as %T: %s", e.value, e.targetType, e.err)
+}
+
+// NewEncodingError wraps err as an encoding error for value into targetType.
+func NewEncodingError(err error, targetType, value interface{}) EncodingError {
+	return EncodingError{
+		err:        err,
+		targetType: targetType,
+		value:      value,
+	}
+}

--- a/vendor/github.com/storageos/go-api/v2/api/openapi.yaml
+++ b/vendor/github.com/storageos/go-api/v2/api/openapi.yaml
@@ -1,0 +1,6475 @@
+openapi: 3.0.2
+info:
+  contact:
+    email: info@storageos.com
+    name: StorageOS
+    url: https://storageos.com
+  title: StorageOS API
+  version: 2.4.0-alpha
+externalDocs:
+  description: The latest StorageOS user documentation
+  url: https://docs.storageos.com/
+servers:
+- url: /v2
+paths:
+  /auth/login:
+    post:
+      description: Generate a new JWT token for a user.
+      operationId: authenticateUser
+      requestBody:
+        $ref: '#/components/requestBodies/AuthUserData'
+        content:
+          application/json:
+            schema:
+              example:
+                username: admin
+                password: supersecret
+              properties:
+                username:
+                  type: string
+                password:
+                  format: password
+                  type: string
+              required:
+              - password
+              - username
+              title: AuthUserData
+              type: object
+        description: The credentials to use for authentication.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserSession'
+          description: Successfully authenticated the returned user.
+          headers:
+            Authorization:
+              description: |
+                The JWT token - this header should be sent to the server to perform an authenticated request.
+              explode: false
+              schema:
+                type: string
+              style: simple
+            Authorization-Expires-Seconds:
+              description: |
+                A formatted string representing the number of  seconds after which the login session will  expire.
+              explode: false
+              schema:
+                example: 60
+                type: uint64
+              style: simple
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      summary: Authenticate a user
+  /auth/refresh:
+    post:
+      description: Obtain a fresh token with an updated expiry deadline.
+      operationId: refreshJwt
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserSession'
+          description: Refresh was successful
+          headers:
+            Authorization:
+              description: The new JWT token.
+              explode: false
+              schema:
+                type: string
+              style: simple
+            Authorization-Expires-In:
+              description: |
+                A formatted string representing the duration  after which the refreshed token will expire.
+              explode: false
+              schema:
+                example: 60
+                type: uint64
+              style: simple
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Refresh the JWT
+  /users:
+    get:
+      description: Fetch the list of users of the cluster.
+      operationId: listUsers
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserList'
+          description: A list of cluster users.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Fetch the list of users
+    post:
+      description: |
+        Create a new user in the cluster - only administrators can create new users.
+      operationId: createUser
+      requestBody:
+        $ref: '#/components/requestBodies/CreateUserData'
+        content:
+          application/json:
+            schema:
+              example:
+                password: turtlesaregreat
+                groups:
+                - 24d5db6f-9738-4f17-a257-b9dd41a35309
+                - 4223b453-4d47-49d5-960f-23fc7a8153ba
+                isAdmin: true
+                username: admin
+              properties:
+                username:
+                  example: admin
+                  type: string
+                password:
+                  default: unchanged
+                  description: If not present, the existing password is not changed
+                  example: turtlesaregreat
+                  format: password
+                  type: string
+                  writeOnly: true
+                isAdmin:
+                  default: false
+                  description: |
+                    If true, this user is an administrator of the cluster.
+                    Administrators bypass the usual authentication checks and are granted access to all resources. Some actions (such as adding a new user) can only be performed by an administrator.
+                  example: true
+                  type: boolean
+                groups:
+                  default: []
+                  description: |
+                    Defines a set of policy group IDs this user is a member of.
+                    Policy groups can be used to logically group users and apply authorisation  policies to all members.
+                  example:
+                  - 24d5db6f-9738-4f17-a257-b9dd41a35309
+                  - 4223b453-4d47-49d5-960f-23fc7a8153ba
+                  items:
+                    $ref: '#/components/schemas/PolicyGroupID'
+                  nullable: true
+                  type: array
+              required:
+              - password
+              - username
+              title: CreateUserData
+              type: object
+        description: Data required to create a new user in the cluster.
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: The account was successfully created
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "409":
+          content:
+            application/json:
+              example:
+                error: already exists
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote uses an identifier that already exists.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Create a new user
+  /users/{id}:
+    delete:
+      description: |
+        Remove the user identified by id.
+        This request will not succeed if the target account is the currently authenticated account. Use the separate users/self endpoint for this purpose.
+      operationId: deleteUser
+      parameters:
+      - description: ID of a user
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/UserID'
+        style: simple
+      - description: |
+          This value is used to perform a conditional delete or update of the entity.
+          If the entity has been modified since the version token was obtained, the request will fail with a HTTP 409 Conflict.
+        explode: true
+        in: query
+        name: version
+        required: true
+        schema:
+          $ref: '#/components/schemas/Version'
+        style: form
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      responses:
+        "200":
+          description: The user was successfully deleted.
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Delete a user
+    get:
+      description: Fetch the user identified by id.
+      operationId: getUser
+      parameters:
+      - description: ID of a user
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/UserID'
+        style: simple
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: The user information.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Fetch a user
+    put:
+      description: |
+        Update the user identified by id.
+        This request will not succeed if the target account is the currently authenticated account. Use the separate users/self endpoint for this purpose.
+      operationId: updateUser
+      parameters:
+      - description: ID of a user
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/UserID'
+        style: simple
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateUserData'
+        content:
+          application/json:
+            schema:
+              example:
+                password: turtlesaregreat
+                groups:
+                - 24d5db6f-9738-4f17-a257-b9dd41a35309
+                - 4223b453-4d47-49d5-960f-23fc7a8153ba
+                isAdmin: true
+                version: NDI0MjQyNDI0MjQyNDI0MjQy
+              properties:
+                password:
+                  default: unchanged
+                  description: If not present, the existing password is not changed
+                  example: turtlesaregreat
+                  format: password
+                  type: string
+                  writeOnly: true
+                isAdmin:
+                  default: false
+                  description: |
+                    If true, this user is an administrator of the cluster.
+                    Administrators bypass the usual authentication checks and are granted access to all resources. Some actions (such as adding a new user) can only be performed by an administrator.
+                  example: true
+                  type: boolean
+                groups:
+                  default: []
+                  description: |
+                    Defines a set of policy group IDs this user is a member of.
+                    Policy groups can be used to logically group users and apply authorisation  policies to all members.
+                  example:
+                  - 24d5db6f-9738-4f17-a257-b9dd41a35309
+                  - 4223b453-4d47-49d5-960f-23fc7a8153ba
+                  items:
+                    $ref: '#/components/schemas/PolicyGroupID'
+                  nullable: true
+                  type: array
+                version:
+                  description: |
+                    An opaque representation of an entity version at the time it was obtained from the API.
+                    All operations that mutate the entity must include this version field in the request unchanged.
+                    The format of this type is undefined and may change but the defined properties will not change.
+                  example: NDI0MjQyNDI0MjQyNDI0MjQy
+                  maxLength: 30
+                  type: string
+              title: UpdateUserData
+              type: object
+        description: The new User data to store.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: The account was successfully updated
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Update a user
+  /users/{id}/sessions:
+    delete:
+      description: |
+        Invalidates active JWTs on a per-user basis, specified by id.
+        This request will not succeed if the target account is the currently authenticated account. Use the separate users/self endpoint for this purpose.
+      operationId: deleteSessions
+      parameters:
+      - description: ID of a user
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/UserID'
+        style: simple
+      responses:
+        "200":
+          description: The users current session was successfully invalidated.
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Invalidate login sessions
+  /users/self:
+    delete:
+      description: Remove the authenticated user from the cluster.
+      operationId: deleteAuthenticatedUser
+      parameters:
+      - description: |
+          This value is used to perform a conditional delete or update of the entity.
+          If the entity has been modified since the version token was obtained, the request will fail with a HTTP 409 Conflict.
+        explode: true
+        in: query
+        name: version
+        required: true
+        schema:
+          $ref: '#/components/schemas/Version'
+        style: form
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      responses:
+        "200":
+          description: The authenticated user was successfully deleted.
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Delete the authenticated user
+    get:
+      description: Fetch authenticated user's information.
+      operationId: getAuthenticatedUser
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: The authenticated user's information.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Get the currently authenticated user's information
+    put:
+      description: Update the authenticated user.
+      operationId: updateAuthenticatedUser
+      parameters:
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateAuthenticatedUserData'
+        content:
+          application/json:
+            schema:
+              example:
+                password: turtlesaregreat
+                version: NDI0MjQyNDI0MjQyNDI0MjQy
+              properties:
+                password:
+                  default: unchanged
+                  description: If not present, the existing password is not changed
+                  example: turtlesaregreat
+                  format: password
+                  type: string
+                  writeOnly: true
+                version:
+                  description: |
+                    An opaque representation of an entity version at the time it was obtained from the API.
+                    All operations that mutate the entity must include this version field in the request unchanged.
+                    The format of this type is undefined and may change but the defined properties will not change.
+                  example: NDI0MjQyNDI0MjQyNDI0MjQy
+                  maxLength: 30
+                  type: string
+              title: UpdateAuthenticatedUserData
+              type: object
+        description: The new authenticated user's data.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: The account was successfully updated
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Update the authenticated user's information
+  /users/self/sessions:
+    delete:
+      description: Invalidates logged in user's active JWTs.
+      operationId: deleteAuthenticatedUserSessions
+      responses:
+        "200":
+          description: The authenticated user's sessions have been invalidated.
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Invalidate the logged in user's sessions
+  /namespaces:
+    get:
+      description: Fetch the list of namespaces in the cluster.
+      operationId: listNamespaces
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NamespaceList'
+          description: A list of cluster namespaces.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Fetch the list of namespaces
+    post:
+      description: |
+        Create a new namespace in the cluster - only administrators can create new namespaces.
+      operationId: createNamespace
+      requestBody:
+        $ref: '#/components/requestBodies/CreateNamespaceData'
+        content:
+          application/json:
+            schema:
+              example:
+                name: dev
+                labels:
+                  env: prod
+                  rack: db-1
+              properties:
+                name:
+                  description: |
+                    The name of the namespace shown in the CLI and UI
+                  example: dev
+                  pattern: ^[a-z0-9.\-]{1,253}$
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: |
+                    A set of arbitrary key value labels to apply to the entity.
+                  example:
+                    env: prod
+                    rack: db-1
+                  externalDocs:
+                    url: https://docs.storageos.com/v2/openapi-help/labels
+                  type: object
+              title: CreateNamespaceData
+              type: object
+        description: Data required to create a new namespace in the cluster.
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Namespace'
+          description: The namespace was successfully created
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "409":
+          content:
+            application/json:
+              example:
+                error: already exists
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote uses an identifier that already exists.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Create a new namespace
+  /namespaces/{id}:
+    delete:
+      description: Remove the namespace identified by id.
+      operationId: deleteNamespace
+      parameters:
+      - description: ID of a namespace
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/NamespaceID'
+        style: simple
+      - description: |
+          This value is used to perform a conditional delete or update of the entity.
+          If the entity has been modified since the version token was obtained, the request will fail with a HTTP 409 Conflict.
+        explode: true
+        in: query
+        name: version
+        required: true
+        schema:
+          $ref: '#/components/schemas/Version'
+        style: form
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      responses:
+        "200":
+          description: The namespace was successfully deleted.
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "409":
+          content:
+            application/json:
+              example:
+                error: in use
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced entity is currently in use.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Delete a namespace
+    get:
+      description: Fetch the namespace identified by id.
+      operationId: getNamespace
+      parameters:
+      - description: ID of a namespace
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/NamespaceID'
+        style: simple
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Namespace'
+          description: The namespace information.
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Fetch a namespace
+    put:
+      description: Update the namespace identified by id.
+      operationId: updateNamespace
+      parameters:
+      - description: ID of a namespace
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/NamespaceID'
+        style: simple
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateNamespaceData'
+        content:
+          application/json:
+            schema:
+              example:
+                version: NDI0MjQyNDI0MjQyNDI0MjQy
+                labels:
+                  env: prod
+                  rack: db-1
+              properties:
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: |
+                    A set of arbitrary key value labels to apply to the entity.
+                  example:
+                    env: prod
+                    rack: db-1
+                  externalDocs:
+                    url: https://docs.storageos.com/v2/openapi-help/labels
+                  type: object
+                version:
+                  description: |
+                    An opaque representation of an entity version at the time it was obtained from the API.
+                    All operations that mutate the entity must include this version field in the request unchanged.
+                    The format of this type is undefined and may change but the defined properties will not change.
+                  example: NDI0MjQyNDI0MjQyNDI0MjQy
+                  maxLength: 30
+                  type: string
+              title: UpdateNamespaceData
+              type: object
+        description: The new namespace data to store.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Namespace'
+          description: The namespace was successfully updated
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Update a namespace
+  /nodes:
+    get:
+      description: Fetch the list of nodes of the cluster.
+      operationId: listNodes
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeList'
+          description: A list of cluster nodes.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Fetch the list of nodes
+  /nodes/{id}:
+    delete:
+      description: |
+        Remove the node identified by id.
+        A node can only be deleted if it is currently offline and does not host any master deployments.
+      operationId: deleteNode
+      parameters:
+      - description: ID of a node
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/NodeID'
+        style: simple
+      - description: |
+          This value is used to perform a conditional delete or update of the entity.
+          If the entity has been modified since the version token was obtained, the request will fail with a HTTP 409 Conflict.
+        explode: true
+        in: query
+        name: version
+        required: true
+        schema:
+          $ref: '#/components/schemas/Version'
+        style: form
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      - description: |
+          Optional parameter which will make the api request asynchronous. The operation will not be cancelled even if the client disconnect.
+          The URL parameter value overrides the "async-max" header value, if any.
+          The value of this header defines the timeout duration for the request, it must be set to a valid duration string.
+          A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+          We reject negative or nil duration values.
+        explode: true
+        in: query
+        name: async-max
+        required: false
+        schema:
+          type: string
+        style: form
+      responses:
+        "200":
+          description: The node was successfully deleted.
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AcceptedMessage'
+          description: |
+            An aynchronous request has been accepted
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "409":
+          content:
+            application/json:
+              example:
+                error: in use
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced entity is currently in use.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "423":
+          content:
+            application/json:
+              example:
+                error: entity locked
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A lock is held for the target entity, preventing the operation to be carried out safely.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Delete a node
+    get:
+      description: Fetch the node identified by id.
+      operationId: getNode
+      parameters:
+      - description: ID of a node
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/NodeID'
+        style: simple
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+          description: The node information.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Fetch a node
+    put:
+      description: |
+        Update the non-storageos labels configured for the node  identified by id.
+      operationId: updateNode
+      parameters:
+      - description: ID of a node
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/NodeID'
+        style: simple
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateNodeData'
+        content:
+          application/json:
+            schema:
+              example:
+                version: NDI0MjQyNDI0MjQyNDI0MjQy
+                labels:
+                  env: prod
+                  rack: db-1
+              properties:
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: |
+                    A set of arbitrary key value labels to apply to the entity.
+                  example:
+                    env: prod
+                    rack: db-1
+                  externalDocs:
+                    url: https://docs.storageos.com/v2/openapi-help/labels
+                  type: object
+                version:
+                  description: |
+                    An opaque representation of an entity version at the time it was obtained from the API.
+                    All operations that mutate the entity must include this version field in the request unchanged.
+                    The format of this type is undefined and may change but the defined properties will not change.
+                  example: NDI0MjQyNDI0MjQyNDI0MjQy
+                  maxLength: 30
+                  type: string
+              title: UpdateNodeData
+              type: object
+        description: "Update the label configuration of the node to the desired state.\
+          \ Alterations of StorageOS labels are rejected. \n"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+          description: The node was successfully updated
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Update a node
+  /nodes/{id}/compute-only:
+    put:
+      description: |
+        Set the compute-only configuration state for the node corresponding  to id given by the request.
+      operationId: setComputeOnly
+      parameters:
+      - description: ID of a Node
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/NodeID'
+        style: simple
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      requestBody:
+        $ref: '#/components/requestBodies/SetComputeOnlyNodeData'
+        content:
+          application/json:
+            schema:
+              example:
+                computeOnly: true
+                version: NDI0MjQyNDI0MjQyNDI0MjQy
+              properties:
+                computeOnly:
+                  description: |
+                    Marks the node's desired configuration  state as compute-only. This will result in the node being avoided for volume placement
+                  example: true
+                  type: boolean
+                version:
+                  description: |
+                    An opaque representation of an entity version at the time it was obtained from the API.
+                    All operations that mutate the entity must include this version field in the request unchanged.
+                    The format of this type is undefined and may change but the defined properties will not change.
+                  example: NDI0MjQyNDI0MjQyNDI0MjQy
+                  maxLength: 30
+                  type: string
+              title: SetComputeOnlyNodeData
+              type: object
+        description: Desired compute-only configuration state for the node.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+          description: The node was successfullly updated
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Modify the computeonly behaviour state for a node
+  /policies:
+    get:
+      description: Fetch the list of policy groups in the cluster.
+      operationId: listPolicyGroups
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyGroupList'
+          description: A list of cluster policy groups.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Fetch the list of policy groups
+    post:
+      description: |
+        Create a new policy group in the cluster - only administrators can create new policy groups.
+      operationId: createPolicyGroup
+      requestBody:
+        $ref: '#/components/requestBodies/CreatePolicyGroupData'
+        content:
+          application/json:
+            schema:
+              example:
+                specs:
+                - namespaceID: 251f065a-d89b-4426-a752-5fdd144d00e8
+                  resourceType: '*'
+                  readOnly: false
+                - namespaceID: 5f009d1f-6618-43c2-9ae4-e699461dda8e
+                  resourceType: volume
+                  readOnly: true
+                name: dev-users
+              properties:
+                name:
+                  example: dev-users
+                  type: string
+                specs:
+                  default: []
+                  description: A set of authorisation policies to apply to the policy
+                    group.
+                  example:
+                  - namespaceID: 251f065a-d89b-4426-a752-5fdd144d00e8
+                    resourceType: '*'
+                    readOnly: false
+                  - namespaceID: 5f009d1f-6618-43c2-9ae4-e699461dda8e
+                    resourceType: volume
+                    readOnly: true
+                  items:
+                    $ref: '#/components/schemas/_policies_specs'
+                  nullable: true
+                  type: array
+              title: CreatePolicyGroupData
+              type: object
+        description: Data required to create a new policy group in the cluster.
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyGroup'
+          description: The policy group was successfully created
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "409":
+          content:
+            application/json:
+              example:
+                error: already exists
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote uses an identifier that already exists.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Create a new policy group
+  /policies/{id}:
+    delete:
+      description: Remove the policy group identified by id.
+      operationId: deletePolicyGroup
+      parameters:
+      - description: ID of a policy group
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/PolicyGroupID'
+        style: simple
+      - description: |
+          This value is used to perform a conditional delete or update of the entity.
+          If the entity has been modified since the version token was obtained, the request will fail with a HTTP 409 Conflict.
+        explode: true
+        in: query
+        name: version
+        required: true
+        schema:
+          $ref: '#/components/schemas/Version'
+        style: form
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      responses:
+        "200":
+          description: The policy group was successfully deleted.
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "409":
+          content:
+            application/json:
+              example:
+                error: in use
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced entity is currently in use.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Delete a policy group
+    get:
+      description: Fetch the policy group identified by id.
+      operationId: getPolicyGroup
+      parameters:
+      - description: ID of a policy group
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/PolicyGroupID'
+        style: simple
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyGroup'
+          description: The policy group information.
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Fetch a policy group
+    put:
+      description: Update the policy group identified by id.
+      operationId: updatePolicyGroup
+      parameters:
+      - description: ID of a policy group
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/PolicyGroupID'
+        style: simple
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      requestBody:
+        $ref: '#/components/requestBodies/UpdatePolicyGroupData'
+        content:
+          application/json:
+            schema:
+              example:
+                specs:
+                - namespaceID: 251f065a-d89b-4426-a752-5fdd144d00e8
+                  resourceType: '*'
+                  readOnly: false
+                - namespaceID: 5f009d1f-6618-43c2-9ae4-e699461dda8e
+                  resourceType: volume
+                  readOnly: true
+                version: NDI0MjQyNDI0MjQyNDI0MjQy
+              properties:
+                specs:
+                  default: []
+                  description: A set of authorisation policies to apply to the policy
+                    group.
+                  example:
+                  - namespaceID: 251f065a-d89b-4426-a752-5fdd144d00e8
+                    resourceType: '*'
+                    readOnly: false
+                  - namespaceID: 5f009d1f-6618-43c2-9ae4-e699461dda8e
+                    resourceType: volume
+                    readOnly: true
+                  items:
+                    $ref: '#/components/schemas/_policies__id__specs'
+                  nullable: true
+                  type: array
+                version:
+                  description: |
+                    An opaque representation of an entity version at the time it was obtained from the API.
+                    All operations that mutate the entity must include this version field in the request unchanged.
+                    The format of this type is undefined and may change but the defined properties will not change.
+                  example: NDI0MjQyNDI0MjQyNDI0MjQy
+                  maxLength: 30
+                  type: string
+              title: UpdatePolicyGroupData
+              type: object
+        description: The new policy group data to store.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyGroup'
+          description: The policy group was successfully updated
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Update a policy group
+  /namespaces/{namespaceID}/volumes:
+    get:
+      description: Fetch the list of volumes in the cluster.
+      operationId: listVolumes
+      parameters:
+      - description: ID of a Namespace
+        explode: false
+        in: path
+        name: namespaceID
+        required: true
+        schema:
+          $ref: '#/components/schemas/NamespaceID'
+        style: simple
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VolumeList'
+          description: A list of the namespace's volumes.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Fetch the list of volumes in the given namespace
+    post:
+      description: Create a new volume in the given namespace
+      operationId: createVolume
+      parameters:
+      - description: ID of a Namespace
+        explode: false
+        in: path
+        name: namespaceID
+        required: true
+        schema:
+          $ref: '#/components/schemas/NamespaceID'
+        style: simple
+      - description: |
+          Optional parameter which will make the api request asynchronous. The operation will not be cancelled even if the client disconnect.
+          The URL parameter value overrides the "async-max" header value, if any.
+          The value of this header defines the timeout duration for the request, it must be set to a valid duration string.
+          A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+          We reject negative or nil duration values.
+        explode: true
+        in: query
+        name: async-max
+        required: false
+        schema:
+          type: string
+        style: form
+      requestBody:
+        $ref: '#/components/requestBodies/CreateVolumeData'
+        content:
+          application/json:
+            schema:
+              example:
+                namespaceID: c5666b58-b805-4215-ab4a-cb094948ccc6
+                name: data
+                description: This volume contains the data for my app
+                fsType: ext4
+                labels:
+                  env: prod
+                  rack: db-1
+                sizeBytes: 5000
+              properties:
+                namespaceID:
+                  description: |
+                    A unique identifier for a namespace. The format of this type is undefined and may change but the defined properties will not change..
+                  example: c5666b58-b805-4215-ab4a-cb094948ccc6
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: |
+                    A set of arbitrary key value labels to apply to the entity.
+                  example:
+                    env: prod
+                    rack: db-1
+                  externalDocs:
+                    url: https://docs.storageos.com/v2/openapi-help/labels
+                  type: object
+                name:
+                  description: |
+                    The name of the volume shown in the CLI and UI
+                  example: data
+                  pattern: ^[a-z0-9.\-]{1,253}$
+                  type: string
+                fsType:
+                  $ref: '#/components/schemas/FsType'
+                description:
+                  example: This volume contains the data for my app
+                  type: string
+                sizeBytes:
+                  description: |
+                    A volume's size in bytes
+                  example: 5000
+                  minimum: 0
+                  type: uint64
+              required:
+              - fsType
+              - name
+              - namespaceID
+              - sizeBytes
+              title: CreateVolumeData
+              type: object
+        description: Data required to create a new volume in the cluster.
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Volume'
+          description: The volume was successfully created
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AcceptedMessage'
+          description: |
+            An aynchronous request has been accepted
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "409":
+          content:
+            application/json:
+              example:
+                error: already exists
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote uses an identifier that already exists.
+        "451":
+          content:
+            application/json:
+              example:
+                error: insufficient allowed capacity (bytes) (used 53687091200, allowed
+                  53687091200, requested 5000000)
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested operation failed because your storageOS licence does not allow it, either create an account for a free licence or buy a professional licence.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "507":
+          content:
+            application/json:
+              example:
+                error: insufficient storage capacity available
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            Available storage is not enough to handle the request or target node has reached maximum number of attached volumes.
+      security:
+      - jwt: []
+      summary: Create a new Volume in the specified namespace
+  /namespaces/{namespaceID}/volumes/{id}:
+    delete:
+      description: Remove the volume identified by id.
+      operationId: deleteVolume
+      parameters:
+      - description: ID of a Namespace
+        explode: false
+        in: path
+        name: namespaceID
+        required: true
+        schema:
+          $ref: '#/components/schemas/NamespaceID'
+        style: simple
+      - description: ID of a Volume
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/VolumeID'
+        style: simple
+      - description: |
+          This value is used to perform a conditional delete or update of the entity.
+          If the entity has been modified since the version token was obtained, the request will fail with a HTTP 409 Conflict.
+        explode: true
+        in: query
+        name: version
+        required: true
+        schema:
+          $ref: '#/components/schemas/Version'
+        style: form
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      - description: |
+          Optional parameter which will make the api request asynchronous. The operation will not be cancelled even if the client disconnect.
+          The URL parameter value overrides the "async-max" header value, if any.
+          The value of this header defines the timeout duration for the request, it must be set to a valid duration string.
+          A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+          We reject negative or nil duration values.
+        explode: true
+        in: query
+        name: async-max
+        required: false
+        schema:
+          type: string
+        style: form
+      - description: |
+          If set to true, enables deletion of a volume when all  deployments are offline, bypassing the host nodes which cannot be reached.
+          An offline delete request will be rejected when either a) there are online deployments for the target volume or b) there is evidence that an unreachable node still has the volume master
+        explode: true
+        in: query
+        name: offline-delete
+        required: false
+        schema:
+          default: false
+          example: true
+          type: boolean
+        style: form
+      responses:
+        "200":
+          description: The volume was successfully deleted.
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AcceptedMessage'
+          description: |
+            An aynchronous request has been accepted
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "409":
+          content:
+            application/json:
+              example:
+                error: in use
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced entity is currently in use.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "422":
+          content:
+            application/json:
+              example:
+                error: invalid state for operation (currently "deleted")
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            An action was requested that cannot be performed on the entity in it's current state.
+            As an example, this error might be returned when trying to delete a currently mounted volume.
+        "423":
+          content:
+            application/json:
+              example:
+                error: entity locked
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A lock is held for the target entity, preventing the operation to be carried out safely.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Delete a volume
+    get:
+      description: Fetch the volume identified by id.
+      operationId: getVolume
+      parameters:
+      - description: ID of a Namespace
+        explode: false
+        in: path
+        name: namespaceID
+        required: true
+        schema:
+          $ref: '#/components/schemas/NamespaceID'
+        style: simple
+      - description: ID of a Volume
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/VolumeID'
+        style: simple
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Volume'
+          description: The volume information.
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Fetch a volume
+    put:
+      description: |
+        Update the description and non-storageos labels configured for the volume identified by id.
+      operationId: updateVolume
+      parameters:
+      - description: ID of a Namespace
+        explode: false
+        in: path
+        name: namespaceID
+        required: true
+        schema:
+          $ref: '#/components/schemas/NamespaceID'
+        style: simple
+      - description: ID of a Volume
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/VolumeID'
+        style: simple
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      - description: |
+          Optional parameter which will make the api request asynchronous. The operation will not be cancelled even if the client disconnect.
+          The URL parameter value overrides the "async-max" header value, if any.
+          The value of this header defines the timeout duration for the request, it must be set to a valid duration string.
+          A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+          We reject negative or nil duration values.
+        explode: true
+        in: query
+        name: async-max
+        required: false
+        schema:
+          type: string
+        style: form
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateVolumeData'
+        content:
+          application/json:
+            schema:
+              example:
+                description: This volume contains the data for my app
+                version: NDI0MjQyNDI0MjQyNDI0MjQy
+                labels:
+                  env: prod
+                  rack: db-1
+              properties:
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: |
+                    A set of arbitrary key value labels to apply to the entity.
+                  example:
+                    env: prod
+                    rack: db-1
+                  externalDocs:
+                    url: https://docs.storageos.com/v2/openapi-help/labels
+                  type: object
+                description:
+                  example: This volume contains the data for my app
+                  type: string
+                version:
+                  description: |
+                    An opaque representation of an entity version at the time it was obtained from the API.
+                    All operations that mutate the entity must include this version field in the request unchanged.
+                    The format of this type is undefined and may change but the defined properties will not change.
+                  example: NDI0MjQyNDI0MjQyNDI0MjQy
+                  maxLength: 30
+                  type: string
+              title: UpdateVolumeData
+              type: object
+        description: |
+          Update the volume description and label configuration to the desired state. Alterations of StorageOS labels are rejected.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Volume'
+          description: The volume was successfully updated
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "451":
+          content:
+            application/json:
+              example:
+                error: insufficient allowed capacity (bytes) (used 53687091200, allowed
+                  53687091200, requested 5000000)
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested operation failed because your storageOS licence does not allow it, either create an account for a free licence or buy a professional licence.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Update a volume
+  /namespaces/{namespaceID}/volumes/{id}/attach:
+    delete:
+      description: Detach the volume identified by id.
+      operationId: detachVolume
+      parameters:
+      - description: ID of a Namespace
+        explode: false
+        in: path
+        name: namespaceID
+        required: true
+        schema:
+          $ref: '#/components/schemas/NamespaceID'
+        style: simple
+      - description: ID of a Volume
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/VolumeID'
+        style: simple
+      - description: |
+          This value is used to perform a conditional delete or update of the entity.
+          If the entity has been modified since the version token was obtained, the request will fail with a HTTP 409 Conflict.
+        explode: true
+        in: query
+        name: version
+        required: true
+        schema:
+          $ref: '#/components/schemas/Version'
+        style: form
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      - description: |
+          Optional parameter which will make the api request asynchronous. The operation will not be cancelled even if the client disconnect.
+          The URL parameter value overrides the "async-max" header value, if any.
+          The value of this header defines the timeout duration for the request, it must be set to a valid duration string.
+          A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+          We reject negative or nil duration values.
+        explode: true
+        in: query
+        name: async-max
+        required: false
+        schema:
+          type: string
+        style: form
+      responses:
+        "200":
+          description: The volume was successfully detached.
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "409":
+          content:
+            application/json:
+              example:
+                error: in use
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced entity is currently in use.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "422":
+          content:
+            application/json:
+              example:
+                error: invalid state for operation (currently "deleted")
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            An action was requested that cannot be performed on the entity in it's current state.
+            As an example, this error might be returned when trying to delete a currently mounted volume.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Detach the given volume
+    post:
+      description: |
+        Attach the volume identified by id to the node identified in the request's body.
+      operationId: attachVolume
+      parameters:
+      - description: ID of a Namespace
+        explode: false
+        in: path
+        name: namespaceID
+        required: true
+        schema:
+          $ref: '#/components/schemas/NamespaceID'
+        style: simple
+      - description: ID of a Volume
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/VolumeID'
+        style: simple
+      requestBody:
+        $ref: '#/components/requestBodies/AttachVolumeData'
+        content:
+          application/json:
+            schema:
+              example:
+                nodeID: c5666b58-b805-4215-ab4a-cb094948ccc6
+              properties:
+                nodeID:
+                  description: |
+                    A unique identifier for a node. The format of this type is undefined and may change but the defined properties will not change.
+                  example: c5666b58-b805-4215-ab4a-cb094948ccc6
+                  readOnly: true
+                  type: string
+              title: AttachVolumeData
+              type: object
+        description: Node ID to which the volume will be attached.
+        required: true
+      responses:
+        "200":
+          description: The volume was successfully attached.
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "409":
+          content:
+            application/json:
+              example:
+                error: in use
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced entity is currently in use.
+        "422":
+          content:
+            application/json:
+              example:
+                error: invalid state for operation (currently "deleted")
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            An action was requested that cannot be performed on the entity in it's current state.
+            As an example, this error might be returned when trying to delete a currently mounted volume.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "507":
+          content:
+            application/json:
+              example:
+                error: insufficient storage capacity available
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            Available storage is not enough to handle the request or target node has reached maximum number of attached volumes.
+      security:
+      - jwt: []
+      summary: Attach a volume to the given node
+  /namespaces/{namespaceID}/volumes/{id}/nfs/attach:
+    post:
+      description: |
+        Attach the given volume as an NFS volume.
+        If no export configuration has been set via the /nfs/export-config endpoint, the nfs service will start with defaults settings (sharing the volume at its root).
+      operationId: attachNFSVolume
+      parameters:
+      - description: ID of a Namespace
+        explode: false
+        in: path
+        name: namespaceID
+        required: true
+        schema:
+          $ref: '#/components/schemas/NamespaceID'
+        style: simple
+      - description: ID of a Volume
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/VolumeID'
+        style: simple
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      - description: |
+          Optional parameter which will make the api request asynchronous. The operation will not be cancelled even if the client disconnect.
+          The URL parameter value overrides the "async-max" header value, if any.
+          The value of this header defines the timeout duration for the request, it must be set to a valid duration string.
+          A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+          We reject negative or nil duration values.
+        explode: true
+        in: query
+        name: async-max
+        required: false
+        schema:
+          type: string
+        style: form
+      requestBody:
+        $ref: '#/components/requestBodies/AttachNFSVolumeData'
+        content:
+          application/json:
+            schema:
+              properties:
+                version:
+                  description: |
+                    An opaque representation of an entity version at the time it was obtained from the API.
+                    All operations that mutate the entity must include this version field in the request unchanged.
+                    The format of this type is undefined and may change but the defined properties will not change.
+                  example: NDI0MjQyNDI0MjQyNDI0MjQy
+                  maxLength: 30
+                  type: string
+              title: AttachNFSVolumeData
+              type: object
+        description: NFS volume configuration. The version is the corresponding volume's
+          version.
+        required: true
+      responses:
+        "200":
+          description: The volume was successfully attached.
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "409":
+          content:
+            application/json:
+              example:
+                error: in use
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced entity is currently in use.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "422":
+          content:
+            application/json:
+              example:
+                error: invalid state for operation (currently "deleted")
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            An action was requested that cannot be performed on the entity in it's current state.
+            As an example, this error might be returned when trying to delete a currently mounted volume.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: attach and share the volume using NFS
+  /namespaces/{namespaceID}/volumes/{id}/nfs/mount-endpoint:
+    put:
+      description: |
+        Update the NFS volume's mount endpoint
+      operationId: updateNFSVolumeMountEndpoint
+      parameters:
+      - description: ID of a Namespace
+        explode: false
+        in: path
+        name: namespaceID
+        required: true
+        schema:
+          $ref: '#/components/schemas/NamespaceID'
+        style: simple
+      - description: ID of a Volume
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/VolumeID'
+        style: simple
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      - description: |
+          Optional parameter which will make the api request asynchronous. The operation will not be cancelled even if the client disconnect.
+          The URL parameter value overrides the "async-max" header value, if any.
+          The value of this header defines the timeout duration for the request, it must be set to a valid duration string.
+          A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+          We reject negative or nil duration values.
+        explode: true
+        in: query
+        name: async-max
+        required: false
+        schema:
+          type: string
+        style: form
+      requestBody:
+        $ref: '#/components/requestBodies/NFSVolumeMountEndpoint'
+        content:
+          application/json:
+            schema:
+              properties:
+                mountEndpoint:
+                  default: ""
+                  description: |
+                    The address to which the NFS server is bound.
+                  type: string
+                version:
+                  description: |
+                    An opaque representation of an entity version at the time it was obtained from the API.
+                    All operations that mutate the entity must include this version field in the request unchanged.
+                    The format of this type is undefined and may change but the defined properties will not change.
+                  example: NDI0MjQyNDI0MjQyNDI0MjQy
+                  maxLength: 30
+                  type: string
+              title: NFSVolumeMountEndpoint
+              type: object
+        description: |
+          Update an existing NFS volume's mount endpoint
+        required: true
+      responses:
+        "200":
+          description: The volume's mount endpoint was successfully updated.
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "409":
+          content:
+            application/json:
+              example:
+                error: in use
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced entity is currently in use.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Update an nfs volume's mount endpoint
+  /namespaces/{namespaceID}/volumes/{id}/nfs/export-config:
+    put:
+      description: |
+        Update the NFS volume's export configuration
+      operationId: updateNFSVolumeExports
+      parameters:
+      - description: ID of a Namespace
+        explode: false
+        in: path
+        name: namespaceID
+        required: true
+        schema:
+          $ref: '#/components/schemas/NamespaceID'
+        style: simple
+      - description: ID of a Volume
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/VolumeID'
+        style: simple
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      - description: |
+          Optional parameter which will make the api request asynchronous. The operation will not be cancelled even if the client disconnect.
+          The URL parameter value overrides the "async-max" header value, if any.
+          The value of this header defines the timeout duration for the request, it must be set to a valid duration string.
+          A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+          We reject negative or nil duration values.
+        explode: true
+        in: query
+        name: async-max
+        required: false
+        schema:
+          type: string
+        style: form
+      requestBody:
+        $ref: '#/components/requestBodies/NFSVolumeExports'
+        content:
+          application/json:
+            schema:
+              properties:
+                exports:
+                  items:
+                    $ref: '#/components/schemas/NfsExportConfig'
+                  type: array
+                version:
+                  description: |
+                    An opaque representation of an entity version at the time it was obtained from the API.
+                    All operations that mutate the entity must include this version field in the request unchanged.
+                    The format of this type is undefined and may change but the defined properties will not change.
+                  example: NDI0MjQyNDI0MjQyNDI0MjQy
+                  maxLength: 30
+                  type: string
+              title: NFSVolumeExports
+              type: object
+        description: |
+          Updates an existing volume's NFS export configuration.
+          The volume will use the given export configuration once attached.
+        required: true
+      responses:
+        "200":
+          description: The volume's NFS export configuration was successfully updated.
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "409":
+          content:
+            application/json:
+              example:
+                error: in use
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced entity is currently in use.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Update an nfs volume's export configuration
+  /namespaces/{namespaceID}/volumes/{id}/replicas:
+    put:
+      description: |
+        Set the number of replicas for the volume identified by id to the number specified in the request's body. This modifies the protected StorageOS system label "storageos.com/replicas".
+        This request changes the desired replica count, and returns an error if changing the desired replica count failed. StorageOS satisfies the new replica configuration asynchronously.
+      operationId: setReplicas
+      parameters:
+      - description: ID of a Namespace
+        explode: false
+        in: path
+        name: namespaceID
+        required: true
+        schema:
+          $ref: '#/components/schemas/NamespaceID'
+        style: simple
+      - description: ID of a Volume
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/VolumeID'
+        style: simple
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      requestBody:
+        $ref: '#/components/requestBodies/SetReplicasRequest'
+        content:
+          application/json:
+            schema:
+              example:
+                replicas: 2
+                version: NDI0MjQyNDI0MjQyNDI0MjQy
+              properties:
+                replicas:
+                  description: |
+                    The number of replicas desired.
+                  example: 2
+                  maximum: 5
+                  minimum: 0
+                  type: uint64
+                version:
+                  description: |
+                    An opaque representation of an entity version at the time it was obtained from the API.
+                    All operations that mutate the entity must include this version field in the request unchanged.
+                    The format of this type is undefined and may change but the defined properties will not change.
+                  example: NDI0MjQyNDI0MjQyNDI0MjQy
+                  maxLength: 30
+                  type: string
+              title: SetReplicasRequest
+              type: object
+        description: Number of replicas
+        required: true
+      responses:
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AcceptedMessage'
+          description: |
+            An aynchronous request has been accepted
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "422":
+          content:
+            application/json:
+              example:
+                error: invalid state for operation (currently "deleted")
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            An action was requested that cannot be performed on the entity in it's current state.
+            As an example, this error might be returned when trying to delete a currently mounted volume.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Set the number of replicas to maintain for the volume.
+  /namespaces/{namespaceID}/volumes/{id}/size:
+    put:
+      description: |
+        Resize the volume identified by id in the namespace identified by namespaceID. A volume's size cannot be reduced.
+      operationId: resizeVolume
+      parameters:
+      - description: ID of a Namespace
+        explode: false
+        in: path
+        name: namespaceID
+        required: true
+        schema:
+          $ref: '#/components/schemas/NamespaceID'
+        style: simple
+      - description: ID of a Volume
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          $ref: '#/components/schemas/VolumeID'
+        style: simple
+      - description: |
+          Optional parameter which will make the api request asynchronous. The operation will not be cancelled even if the client disconnect.
+          The URL parameter value overrides the "async-max" header value, if any.
+          The value of this header defines the timeout duration for the request, it must be set to a valid duration string.
+          A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+          We reject negative or nil duration values.
+        explode: true
+        in: query
+        name: async-max
+        required: false
+        schema:
+          type: string
+        style: form
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      requestBody:
+        $ref: '#/components/requestBodies/ResizeVolumeRequest'
+        content:
+          application/json:
+            schema:
+              example:
+                version: NDI0MjQyNDI0MjQyNDI0MjQy
+                sizeBytes: 5368709000
+              properties:
+                sizeBytes:
+                  description: |
+                    The desired new size for the volume in  bytes. This value cannot be less than  the current size of the volume.
+                  example: 5368709000
+                  minimum: 1073742000
+                  type: uint64
+                version:
+                  description: |
+                    An opaque representation of an entity version at the time it was obtained from the API.
+                    All operations that mutate the entity must include this version field in the request unchanged.
+                    The format of this type is undefined and may change but the defined properties will not change.
+                  example: NDI0MjQyNDI0MjQyNDI0MjQy
+                  maxLength: 30
+                  type: string
+              title: ResizeVolumeRequest
+              type: object
+        description: The new size to give the volume
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Volume'
+          description: The volume was resized successfully.
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AcceptedMessage'
+          description: |
+            An aynchronous request has been accepted
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "404":
+          content:
+            application/json:
+              example:
+                error: not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            A referenced resource does not exist.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "422":
+          content:
+            application/json:
+              example:
+                error: invalid state for operation (currently "deleted")
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            An action was requested that cannot be performed on the entity in it's current state.
+            As an example, this error might be returned when trying to delete a currently mounted volume.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Increase the size of a volume.
+  /cluster:
+    get:
+      description: |
+        Retrieves the current global configuration settings in use by the cluster.
+      operationId: getCluster
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cluster'
+          description: The cluster-wide configuration information.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Retrieves the cluster's global configuration settings
+    put:
+      description: Update the global configuration settings to use for the cluster.
+      operationId: updateCluster
+      parameters:
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateClusterData'
+        content:
+          application/json:
+            schema:
+              example:
+                disableVersionCheck: false
+                disableCrashReporting: false
+                logFormat: json
+                logLevel: debug
+                disableTelemetry: false
+                version: NDI0MjQyNDI0MjQyNDI0MjQy
+              properties:
+                disableTelemetry:
+                  default: false
+                  description: |
+                    Disables collection of telemetry data across the cluster.
+                  example: false
+                  type: boolean
+                disableCrashReporting:
+                  default: false
+                  description: |
+                    Disables collection of reports for any fatal crashes across the cluster.
+                  example: false
+                  type: boolean
+                disableVersionCheck:
+                  default: false
+                  description: |
+                    Disables the mechanism responsible for checking if there is an updated version of StorageOS available for installation.
+                  example: false
+                  type: boolean
+                logLevel:
+                  $ref: '#/components/schemas/LogLevel'
+                logFormat:
+                  $ref: '#/components/schemas/LogFormat'
+                version:
+                  description: |
+                    An opaque representation of an entity version at the time it was obtained from the API.
+                    All operations that mutate the entity must include this version field in the request unchanged.
+                    The format of this type is undefined and may change but the defined properties will not change.
+                  example: NDI0MjQyNDI0MjQyNDI0MjQy
+                  maxLength: 30
+                  type: string
+              title: UpdateClusterData
+              type: object
+        description: The new cluster-wide configuration settings to apply.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cluster'
+          description: The cluster was successfully updated.
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Update the cluster's global configuration settings
+  /cluster/licence:
+    get:
+      description: |
+        Retrieves the cluster's current licence information
+      operationId: getLicence
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Licence'
+          description: The cluster's licence information.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Retrieves the cluster's licence information
+    put:
+      description: Update the cluster's licence.
+      operationId: updateLicence
+      parameters:
+      - description: |
+          If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+        explode: true
+        in: query
+        name: ignore-version
+        required: false
+        schema:
+          $ref: '#/components/schemas/IgnoreVersion'
+        style: form
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateLicence'
+        content:
+          application/json:
+            schema:
+              example:
+                version: NDI0MjQyNDI0MjQyNDI0MjQy
+                key: key
+              properties:
+                key:
+                  description: |
+                    A StorageOS product licence key, used to register a cluster. The format of this type is opaque and may change.
+                  type: string
+                version:
+                  description: |
+                    An opaque representation of an entity version at the time it was obtained from the API.
+                    All operations that mutate the entity must include this version field in the request unchanged.
+                    The format of this type is undefined and may change but the defined properties will not change.
+                  example: NDI0MjQyNDI0MjQyNDI0MjQy
+                  maxLength: 30
+                  type: string
+              title: UpdateLicence
+              type: object
+        description: |
+          A StorageOS product licence key, used to register a cluster. The format of this type is opaque and may change.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Licence'
+          description: The provided licence was successfully applied.
+        "400":
+          content:
+            application/json:
+              example:
+                error: a short description of the validation failure
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request does not conform to the API specification.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "412":
+          content:
+            application/json:
+              example:
+                error: attempting to write stale object
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+            The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Update the licence global configuration settings
+  /diagnostics:
+    get:
+      description: |
+        Requests that the target node gathers detailed information about the state of the cluster, using it to then build and return a bundle which can be used for troubleshooting.
+        The request will only be served when the authenticated user is an administrator.
+        The node will attempt to gather information about its local state, cluster-wide state and local state of other nodes in the cluster. If the cluster is unhealthy this may cause a slower response.
+      operationId: getDiagnostics
+      responses:
+        "200":
+          content:
+            application/gzip:
+              schema:
+                format: binary
+                type: string
+          description: |
+            A diagnostics bundle was successfully built and returned.
+        "401":
+          content:
+            application/json:
+              example:
+                error: authentication required
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The requested endpoint requires authentication - you must log in first.
+            If attempting to log in, your credentials were not recognised.
+        "403":
+          content:
+            application/json:
+              example:
+                error: unauthorised
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The authenticated user does not have permission to perform the requested action.
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The request caused an internal server error and should be retried.
+            Check the health of the node/cluster and if the error persists, contact support.
+        "502":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is returning an incomplete diagnostic bundle.
+            A bundle may contain partial information if one or more nodes failed to respond, or some other error occured during the collection process.
+            The returned bundle is still valid and should be sent to StorageOS.
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            The server is currently unable to handle the request due to a temporary store failure.
+            Check the health of the node/cluster and if the error persists, contact support.
+      security:
+      - jwt: []
+      summary: Retrieves a diagnostics bundle from the target node
+  /openapi:
+    get:
+      description: Serves this openapi spec file
+      operationId: spec
+      responses:
+        "200":
+          content:
+            text/yaml:
+              schema:
+                $ref: '#/components/schemas/OpenAPISpec'
+          description: The openapi spec file has been served
+      summary: Serves this openapi spec file
+components:
+  parameters:
+    ObjectVersion:
+      description: |
+        This value is used to perform a conditional delete or update of the entity.
+        If the entity has been modified since the version token was obtained, the request will fail with a HTTP 409 Conflict.
+      explode: true
+      in: query
+      name: version
+      required: true
+      schema:
+        $ref: '#/components/schemas/Version'
+      style: form
+    IgnoreVersion:
+      description: |
+        If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+      explode: true
+      in: query
+      name: ignore-version
+      required: false
+      schema:
+        $ref: '#/components/schemas/IgnoreVersion'
+      style: form
+    AsyncHeader:
+      description: |
+        Optional header which will make the api request asynchronous. The operation will not be cancelled even if the client disconnect.
+        The value of this header defines the timeout duration for the request, it must be set to a valid duration string.
+        A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+        We reject negative or nil duration values.
+      example: async-max:20s
+      explode: false
+      in: header
+      name: async-max
+      required: false
+      schema:
+        type: string
+      style: simple
+    AsyncParam:
+      description: |
+        Optional parameter which will make the api request asynchronous. The operation will not be cancelled even if the client disconnect.
+        The URL parameter value overrides the "async-max" header value, if any.
+        The value of this header defines the timeout duration for the request, it must be set to a valid duration string.
+        A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+        We reject negative or nil duration values.
+      explode: true
+      in: query
+      name: async-max
+      required: false
+      schema:
+        type: string
+      style: form
+  requestBodies:
+    SetComputeOnlyNodeData:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SetComputeOnlyNodeData'
+      required: true
+    CreateVolumeData:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreateVolumeData'
+      required: true
+    UpdateVolumeData:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateVolumeData'
+      required: true
+    UpdateUserData:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateUserData'
+      required: true
+    NFSVolumeMountEndpoint:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/NFSVolumeMountEndpoint'
+      required: true
+    CreateUserData:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreateUserData'
+      required: true
+    ResizeVolumeRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ResizeVolumeRequest'
+      required: true
+    UpdateLicence:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateLicence'
+      required: true
+    AttachNFSVolumeData:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AttachNFSVolumeData'
+      required: true
+    CreatePolicyGroupData:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreatePolicyGroupData'
+      required: true
+    UpdatePolicyGroupData:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdatePolicyGroupData'
+      required: true
+    NFSVolumeExports:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/NFSVolumeExports'
+      required: true
+    SetReplicasRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SetReplicasRequest'
+      required: true
+    UpdateAuthenticatedUserData:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateAuthenticatedUserData'
+      required: true
+    AuthUserData:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AuthUserData'
+      required: true
+    UpdateNamespaceData:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateNamespaceData'
+      required: true
+    UpdateNodeData:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateNodeData'
+      required: true
+    UpdateClusterData:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateClusterData'
+      required: true
+    AttachVolumeData:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AttachVolumeData'
+      required: true
+    CreateNamespaceData:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreateNamespaceData'
+      required: true
+  responses:
+    BadRequest:
+      content:
+        application/json:
+          example:
+            error: a short description of the validation failure
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: The request does not conform to the API specification.
+    ServerError:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: |
+        The request caused an internal server error and should be retried.
+        Check the health of the node/cluster and if the error persists, contact support.
+    StoreError:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: |
+        The server is currently unable to handle the request due to a temporary store failure.
+        Check the health of the node/cluster and if the error persists, contact support.
+    LicenceRestricted:
+      content:
+        application/json:
+          example:
+            error: insufficient allowed capacity (bytes) (used 53687091200, allowed
+              53687091200, requested 5000000)
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: |
+        The requested operation failed because your storageOS licence does not allow it, either create an account for a free licence or buy a professional licence.
+    Unauthorised:
+      content:
+        application/json:
+          example:
+            error: authentication required
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: |
+        The requested endpoint requires authentication - you must log in first.
+        If attempting to log in, your credentials were not recognised.
+    Forbidden:
+      content:
+        application/json:
+          example:
+            error: unauthorised
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: |
+        The authenticated user does not have permission to perform the requested action.
+    NotFound:
+      content:
+        application/json:
+          example:
+            error: not found
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: |
+        A referenced resource does not exist.
+    InsufficientStorage:
+      content:
+        application/json:
+          example:
+            error: insufficient storage capacity available
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: |
+        Available storage is not enough to handle the request or target node has reached maximum number of attached volumes.
+    StaleWrite:
+      content:
+        application/json:
+          example:
+            error: attempting to write stale object
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: |
+        The entity to be wrote has been concurrently updated by another request - the submitted entity data has been replaced.
+        The caller should fetch the entity again, check the actions are still required and resubmit the request with the new entity version field.
+    InvalidStateTransition:
+      content:
+        application/json:
+          example:
+            error: invalid state for operation (currently "deleted")
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: |
+        An action was requested that cannot be performed on the entity in it's current state.
+        As an example, this error might be returned when trying to delete a currently mounted volume.
+    AlreadyExists:
+      content:
+        application/json:
+          example:
+            error: already exists
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: |
+        The entity to be wrote uses an identifier that already exists.
+    InUse:
+      content:
+        application/json:
+          example:
+            error: in use
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: |
+        A referenced entity is currently in use.
+    Locked:
+      content:
+        application/json:
+          example:
+            error: entity locked
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: |
+        A lock is held for the target entity, preventing the operation to be carried out safely.
+    Accepted:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AcceptedMessage'
+      description: |
+        An aynchronous request has been accepted
+  schemas:
+    OpenAPISpec:
+      description: |
+        Serves this openapi specification file.
+      readOnly: true
+      type: string
+    Error:
+      example:
+        error: A short description of the error
+      properties:
+        error:
+          type: string
+      required:
+      - error
+      type: object
+    Version:
+      description: |
+        An opaque representation of an entity version at the time it was obtained from the API.
+        All operations that mutate the entity must include this version field in the request unchanged.
+        The format of this type is undefined and may change but the defined properties will not change.
+      example: NDI0MjQyNDI0MjQyNDI0MjQy
+      maxLength: 30
+      type: string
+    IgnoreVersion:
+      default: false
+      description: |
+        Ignoring the entity version constraints.
+        If set to true this value indicates that the user wants to ignore entity version constraints, thereby "forcing" the operation.
+      example: true
+      type: boolean
+    ExpiresAt:
+      description: |
+        The time after which a licence will no longer be valid
+        This timestamp is set when the licence is created.
+        String format is RFC3339.
+      example: 2019-03-10T13:42:42Z
+      format: date-time
+      readOnly: true
+      type: string
+    CreatedAt:
+      description: |
+        The time the entity was created.
+        This timestamp is set by the node that created the entity, and may not be correct if the node's local clock was skewed.
+        This value is for the user's informative purposes only, and correctness is not required.
+        String format is RFC3339.
+      example: 2019-03-10T13:42:42Z
+      format: date-time
+      readOnly: true
+      type: string
+    UpdatedAt:
+      description: |
+        The time the entity was last updated.
+        This timestamp is set by the node that last updated the entity, and may not be correct if the node's local clock was skewed.
+        This value is for the user's informative purposes only, and correctness is not required.
+        String format is RFC3339.
+      example: 2019-03-29T23:13:13Z
+      format: date-time
+      readOnly: true
+      type: string
+    FsType:
+      description: |
+        The file system type of a volume. "block" is a raw block device (no filesystem).
+      enum:
+      - ext2
+      - ext3
+      - ext4
+      - xfs
+      - btrfs
+      - block
+      example: ext4
+      type: string
+    AttachType:
+      description: |
+        The attachment type of a volume. "host" indicates that the volume is consumed by the node it is attached to.
+      enum:
+      - unknown
+      - detached
+      - nfs
+      - host
+      example: host
+      readOnly: true
+      type: string
+    NodeHealth:
+      description: |
+        The operational health of a node entity
+      enum:
+      - online
+      - offline
+      - unknown
+      example: online
+      readOnly: true
+      type: string
+    MasterHealth:
+      description: |
+        The operational health of a volume master deployment
+      enum:
+      - online
+      - offline
+      - unknown
+      example: online
+      readOnly: true
+      type: string
+    ReplicaHealth:
+      description: |
+        The operational health of a volume replica deployment
+      enum:
+      - recovering
+      - provisioning
+      - provisioned
+      - syncing
+      - ready
+      - deleted
+      - failed
+      - unknown
+      example: ready
+      readOnly: true
+      type: string
+    SyncProgress:
+      description: "The progress report for an ongoing sync. \n"
+      properties:
+        bytesRemaining:
+          description: |
+            Number of bytes left remaining to complete the sync.
+          example: 500000
+          type: uint64
+        throughputBytes:
+          description: |
+            The average throughput of the sync given as bytes per  second.
+          example: 100000
+          type: uint64
+        estimatedSecondsRemaining:
+          description: |
+            The estimated time left for the sync to complete, given in seconds. When this field has a value of 0 either the  sync is complete or no duration estimate could be made. The values reported for bytesRemaining and  throughputBytes provide the client with the information needed to choose what to display.
+          example: 5
+          type: uint64
+      readOnly: true
+      type: object
+    CapacityStats:
+      example:
+        total: 42
+        available: 42
+        free: 42
+      properties:
+        total:
+          description: |
+            Total bytes in the filesystem
+          example: 42
+          type: uint64
+        free:
+          description: |
+            Free bytes in the filesystem available to root user
+          example: 42
+          type: uint64
+        available:
+          description: |
+            Byte value available to an unprivileged user
+          example: 42
+          type: uint64
+      type: object
+    NfsAcl:
+      example:
+        squashConfig:
+          uid: ""
+          gid: ""
+          squash: root
+        accessLevel: rw
+        identity:
+          identityType: hostname
+          matcher: '*.prod.storageos.com'
+      properties:
+        identity:
+          $ref: '#/components/schemas/NfsAcl_identity'
+        squashConfig:
+          $ref: '#/components/schemas/NfsAcl_squashConfig'
+        accessLevel:
+          description: |
+            The access level this ACL grants - read-only, or read-write.
+          enum:
+          - ro
+          - rw
+          example: rw
+          type: string
+      type: object
+    NfsExportConfig:
+      example:
+        path: /very/important/files/
+        acls:
+        - squashConfig:
+            uid: ""
+            gid: ""
+            squash: root
+          accessLevel: rw
+          identity:
+            identityType: hostname
+            matcher: '*.prod.storageos.com'
+        - squashConfig:
+            uid: ""
+            gid: ""
+            squash: root
+          accessLevel: rw
+          identity:
+            identityType: hostname
+            matcher: '*.prod.storageos.com'
+        pseudoPath: /very/important/files/somewhere/else
+        exportID: 42
+      properties:
+        exportID:
+          description: |
+            ID for this export
+          example: 42
+          type: uint64
+        path:
+          default: ""
+          description: |
+            The path relative to the volume root to serve as the export root
+          example: /very/important/files/
+          type: string
+        pseudoPath:
+          default: ""
+          description: |
+            The configured pseudo path in the NFS virtual filesystem. This is the path clients will see when traversing to this export on the NFS share.
+          example: /very/important/files/somewhere/else
+          type: string
+        acls:
+          items:
+            $ref: '#/components/schemas/NfsAcl'
+          type: array
+      type: object
+    NfsConfig:
+      example:
+        exports:
+        - path: /very/important/files/
+          acls:
+          - squashConfig:
+              uid: ""
+              gid: ""
+              squash: root
+            accessLevel: rw
+            identity:
+              identityType: hostname
+              matcher: '*.prod.storageos.com'
+          - squashConfig:
+              uid: ""
+              gid: ""
+              squash: root
+            accessLevel: rw
+            identity:
+              identityType: hostname
+              matcher: '*.prod.storageos.com'
+          pseudoPath: /very/important/files/somewhere/else
+          exportID: 42
+        - path: /very/important/files/
+          acls:
+          - squashConfig:
+              uid: ""
+              gid: ""
+              squash: root
+            accessLevel: rw
+            identity:
+              identityType: hostname
+              matcher: '*.prod.storageos.com'
+          - squashConfig:
+              uid: ""
+              gid: ""
+              squash: root
+            accessLevel: rw
+            identity:
+              identityType: hostname
+              matcher: '*.prod.storageos.com'
+          pseudoPath: /very/important/files/somewhere/else
+          exportID: 42
+        serviceEndpoint: serviceEndpoint
+      properties:
+        exports:
+          items:
+            $ref: '#/components/schemas/NfsExportConfig'
+          nullable: true
+          type: array
+        serviceEndpoint:
+          default: ""
+          description: |
+            The address to which the NFS server is bound.
+          nullable: true
+          readOnly: true
+          type: string
+      type: object
+    Labels:
+      additionalProperties:
+        type: string
+      description: |
+        A set of arbitrary key value labels to apply to the entity.
+      example:
+        env: prod
+        rack: db-1
+      externalDocs:
+        url: https://docs.storageos.com/v2/openapi-help/labels
+      type: object
+    LogLevel:
+      default: info
+      description: |
+        This setting determines the log level for nodes across the cluster to use when recording entries in the log. All entries below the specified log level are discarded, where "error" is the highest log level and "debug" is the lowest.
+        This setting is only checked by nodes on startup. Changing this setting will not affect the behaviour of nodes that are already operational.
+      enum:
+      - debug
+      - info
+      - warn
+      - error
+      example: debug
+      type: string
+    LogFormat:
+      default: default
+      description: |
+        This setting determines the format nodes in the cluster will use for log entries.
+        This setting is only checked by nodes on startup. Changing this setting will not affect the behaviour of nodes that are already operational.
+      enum:
+      - default
+      - json
+      example: json
+      type: string
+    ClusterID:
+      description: |
+        A unique identifier for a cluster. The format of this type is undefined and may change but the defined properties will not change.
+      example: c5666b58-b805-4215-ab4a-cb094948ccc6
+      readOnly: true
+      type: string
+    NodeID:
+      description: |
+        A unique identifier for a node. The format of this type is undefined and may change but the defined properties will not change.
+      example: c5666b58-b805-4215-ab4a-cb094948ccc6
+      readOnly: true
+      type: string
+    VolumeID:
+      description: |
+        A unique identifier for a volume. The format of this type is undefined and may change but the defined properties will not change.
+      example: c5666b58-b805-4215-ab4a-cb094948ccc6
+      type: string
+    DeploymentID:
+      description: |
+        A unique identifier for a volume deployment. The format of this type is undefined and may change but the defined properties will not change.
+      example: c5666b58-b805-4215-ab4a-cb094948ccc6
+      type: string
+    NamespaceID:
+      description: |
+        A unique identifier for a namespace. The format of this type is undefined and may change but the defined properties will not change..
+      example: c5666b58-b805-4215-ab4a-cb094948ccc6
+      type: string
+    UserID:
+      description: |
+        A unique identifier for a user. The format of this type is undefined and may change but the defined properties will not change..
+      example: c5666b58-b805-4215-ab4a-cb094948ccc6
+      type: string
+    PolicyGroupID:
+      description: |
+        A unique identifier for a policy group. The format of this type is undefined and may change but the defined properties will not change..
+      example: c5666b58-b805-4215-ab4a-cb094948ccc6
+      type: string
+    Cluster:
+      example:
+        disableVersionCheck: false
+        createdAt: 2019-03-10T13:42:42Z
+        disableCrashReporting: false
+        logFormat: json
+        logLevel: debug
+        disableTelemetry: false
+        id: c5666b58-b805-4215-ab4a-cb094948ccc6
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+        updatedAt: 2019-03-29T23:13:13Z
+      properties:
+        id:
+          description: |
+            A unique identifier for a cluster. The format of this type is undefined and may change but the defined properties will not change.
+          example: c5666b58-b805-4215-ab4a-cb094948ccc6
+          readOnly: true
+          type: string
+        disableTelemetry:
+          default: false
+          description: Disables collection of telemetry data across the cluster.
+          example: false
+          type: boolean
+        disableCrashReporting:
+          default: false
+          description: |
+            Disables collection of reports for any fatal crashes across the cluster.
+          example: false
+          type: boolean
+        disableVersionCheck:
+          default: false
+          description: |
+            Disables the mechanism responsible for checking if there is an updated version of StorageOS available for installation.
+          example: false
+          type: boolean
+        logLevel:
+          $ref: '#/components/schemas/LogLevel'
+        logFormat:
+          $ref: '#/components/schemas/LogFormat'
+        createdAt:
+          description: |
+            The time the entity was created.
+            This timestamp is set by the node that created the entity, and may not be correct if the node's local clock was skewed.
+            This value is for the user's informative purposes only, and correctness is not required.
+            String format is RFC3339.
+          example: 2019-03-10T13:42:42Z
+          format: date-time
+          readOnly: true
+          type: string
+        updatedAt:
+          description: |
+            The time the entity was last updated.
+            This timestamp is set by the node that last updated the entity, and may not be correct if the node's local clock was skewed.
+            This value is for the user's informative purposes only, and correctness is not required.
+            String format is RFC3339.
+          example: 2019-03-29T23:13:13Z
+          format: date-time
+          readOnly: true
+          type: string
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      type: object
+    User:
+      example:
+        createdAt: 2019-03-10T13:42:42Z
+        groups:
+        - 24d5db6f-9738-4f17-a257-b9dd41a35309
+        - 4223b453-4d47-49d5-960f-23fc7a8153ba
+        id: c5666b58-b805-4215-ab4a-cb094948ccc6
+        isAdmin: true
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+        username: admin
+        updatedAt: 2019-03-29T23:13:13Z
+      properties:
+        id:
+          description: |
+            A unique identifier for a user. The format of this type is undefined and may change but the defined properties will not change..
+          example: c5666b58-b805-4215-ab4a-cb094948ccc6
+          type: string
+        username:
+          example: admin
+          type: string
+        isAdmin:
+          default: false
+          description: |
+            If true, this user is an administrator of the cluster.
+            Administrators bypass the usual authentication checks and are granted access to all resources. Some actions (such as adding a new user) can only be performed by an administrator.
+          example: true
+          type: boolean
+        groups:
+          default: []
+          description: |
+            Defines a set of policy group IDs this user is a member of.
+            Policy groups can be used to logically group users and  apply authorisation policies to all members.
+          example:
+          - 24d5db6f-9738-4f17-a257-b9dd41a35309
+          - 4223b453-4d47-49d5-960f-23fc7a8153ba
+          items:
+            $ref: '#/components/schemas/PolicyGroupID'
+          nullable: true
+          type: array
+        createdAt:
+          description: |
+            The time the entity was created.
+            This timestamp is set by the node that created the entity, and may not be correct if the node's local clock was skewed.
+            This value is for the user's informative purposes only, and correctness is not required.
+            String format is RFC3339.
+          example: 2019-03-10T13:42:42Z
+          format: date-time
+          readOnly: true
+          type: string
+        updatedAt:
+          description: |
+            The time the entity was last updated.
+            This timestamp is set by the node that last updated the entity, and may not be correct if the node's local clock was skewed.
+            This value is for the user's informative purposes only, and correctness is not required.
+            String format is RFC3339.
+          example: 2019-03-29T23:13:13Z
+          format: date-time
+          readOnly: true
+          type: string
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      type: object
+    UserSession:
+      allOf:
+      - $ref: '#/components/schemas/User'
+      - $ref: '#/components/schemas/UserSession_allOf'
+    Volume:
+      example:
+        attachmentType: host
+        replicas:
+        - null
+        - null
+        description: This volume contains the data for my app
+        fsType: ext4
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+        labels:
+          env: prod
+          rack: db-1
+        master: ""
+        sizeBytes: 5368709000
+        attachedOn: ""
+        createdAt: 2019-03-10T13:42:42Z
+        namespaceID: ""
+        name: app-data
+        nfs:
+          exports:
+          - path: /very/important/files/
+            acls:
+            - squashConfig:
+                uid: ""
+                gid: ""
+                squash: root
+              accessLevel: rw
+              identity:
+                identityType: hostname
+                matcher: '*.prod.storageos.com'
+            - squashConfig:
+                uid: ""
+                gid: ""
+                squash: root
+              accessLevel: rw
+              identity:
+                identityType: hostname
+                matcher: '*.prod.storageos.com'
+            pseudoPath: /very/important/files/somewhere/else
+            exportID: 42
+          - path: /very/important/files/
+            acls:
+            - squashConfig:
+                uid: ""
+                gid: ""
+                squash: root
+              accessLevel: rw
+              identity:
+                identityType: hostname
+                matcher: '*.prod.storageos.com'
+            - squashConfig:
+                uid: ""
+                gid: ""
+                squash: root
+              accessLevel: rw
+              identity:
+                identityType: hostname
+                matcher: '*.prod.storageos.com'
+            pseudoPath: /very/important/files/somewhere/else
+            exportID: 42
+          serviceEndpoint: serviceEndpoint
+        id: c5666b58-b805-4215-ab4a-cb094948ccc6
+        updatedAt: 2019-03-29T23:13:13Z
+      properties:
+        id:
+          description: |
+            A unique identifier for a volume. The format of this type is undefined and may change but the defined properties will not change.
+          example: c5666b58-b805-4215-ab4a-cb094948ccc6
+          type: string
+        name:
+          example: app-data
+          type: string
+        description:
+          example: This volume contains the data for my app
+          type: string
+        attachedOn:
+          allOf:
+          - $ref: '#/components/schemas/NodeID'
+          readOnly: true
+        nfs:
+          $ref: '#/components/schemas/NfsConfig'
+        namespaceID:
+          allOf:
+          - $ref: '#/components/schemas/NamespaceID'
+          readOnly: true
+        labels:
+          additionalProperties:
+            type: string
+          description: |
+            A set of arbitrary key value labels to apply to the entity.
+          example:
+            env: prod
+            rack: db-1
+          externalDocs:
+            url: https://docs.storageos.com/v2/openapi-help/labels
+          type: object
+        fsType:
+          $ref: '#/components/schemas/FsType'
+        attachmentType:
+          $ref: '#/components/schemas/AttachType'
+        master:
+          allOf:
+          - $ref: '#/components/schemas/MasterDeploymentInfo'
+          readOnly: true
+        replicas:
+          default: []
+          items:
+            $ref: '#/components/schemas/ReplicaDeploymentInfo'
+          nullable: true
+          readOnly: true
+          type: array
+        sizeBytes:
+          description: |
+            A volume's size in bytes
+          example: 5368709000
+          minimum: 1073742000
+          type: uint64
+        createdAt:
+          description: |
+            The time the entity was created.
+            This timestamp is set by the node that created the entity, and may not be correct if the node's local clock was skewed.
+            This value is for the user's informative purposes only, and correctness is not required.
+            String format is RFC3339.
+          example: 2019-03-10T13:42:42Z
+          format: date-time
+          readOnly: true
+          type: string
+        updatedAt:
+          description: |
+            The time the entity was last updated.
+            This timestamp is set by the node that last updated the entity, and may not be correct if the node's local clock was skewed.
+            This value is for the user's informative purposes only, and correctness is not required.
+            String format is RFC3339.
+          example: 2019-03-29T23:13:13Z
+          format: date-time
+          readOnly: true
+          type: string
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      type: object
+    DeploymentInfo:
+      properties:
+        id:
+          description: |
+            A unique identifier for a volume deployment. The format of this type is undefined and may change but the defined properties will not change.
+          example: c5666b58-b805-4215-ab4a-cb094948ccc6
+          type: string
+        nodeID:
+          description: |
+            A unique identifier for a node. The format of this type is undefined and may change but the defined properties will not change.
+          example: c5666b58-b805-4215-ab4a-cb094948ccc6
+          readOnly: true
+          type: string
+        promotable:
+          description: |
+            Indicates if the volume deployment is eligible for promotion
+          type: boolean
+      type: object
+    MasterDeploymentInfo:
+      allOf:
+      - $ref: '#/components/schemas/DeploymentInfo'
+      - $ref: '#/components/schemas/MasterDeploymentInfo_allOf'
+    ReplicaDeploymentInfo:
+      allOf:
+      - $ref: '#/components/schemas/DeploymentInfo'
+      - $ref: '#/components/schemas/ReplicaDeploymentInfo_allOf'
+    Node:
+      example:
+        createdAt: 2019-03-10T13:42:42Z
+        gossipEndpoint: '["192.0.2.1:5711"]'
+        ioEndpoint: '["192.0.2.1:5703"]'
+        name: db1.lcy.storageos.network
+        health: online
+        id: c5666b58-b805-4215-ab4a-cb094948ccc6
+        supervisorEndpoint: '["192.0.2.1:5704"]'
+        clusteringEndpoint: '["192.0.2.1:5710"]'
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+        capacity:
+          total: 42
+          available: 42
+          free: 42
+        labels:
+          env: prod
+          rack: db-1
+        updatedAt: 2019-03-29T23:13:13Z
+      properties:
+        id:
+          description: |
+            A unique identifier for a node. The format of this type is undefined and may change but the defined properties will not change.
+          example: c5666b58-b805-4215-ab4a-cb094948ccc6
+          readOnly: true
+          type: string
+        name:
+          description: |
+            The hostname of the node.
+            This value is set by the node each time it joins the StorageOS cluster.
+          example: db1.lcy.storageos.network
+          readOnly: true
+          type: string
+        health:
+          $ref: '#/components/schemas/NodeHealth'
+        capacity:
+          $ref: '#/components/schemas/CapacityStats'
+        ioEndpoint:
+          description: |
+            Endpoint at which we operate our dataplane's dfs service. (used for IO operations)
+            This value is set on startup by the corresponding environment variable (IO_ADVERTISE_ADDRESS)
+          example: '["192.0.2.1:5703"]'
+          readOnly: true
+          type: string
+        supervisorEndpoint:
+          description: |
+            Endpoint at which we operate our dataplane's supervisor service (used for sync).
+            This value is set on startup by the corresponding environment variable (SUPERVISOR_ADVERTISE_ADDRESS)
+          example: '["192.0.2.1:5704"]'
+          readOnly: true
+          type: string
+        gossipEndpoint:
+          description: |
+            Endpoint at which we operate our health checking service.
+            This value is set on startup by the corresponding environment variable (GOSSIP_ADVERTISE_ADDRESS)
+          example: '["192.0.2.1:5711"]'
+          readOnly: true
+          type: string
+        clusteringEndpoint:
+          description: |
+            Endpoint at which we operate our clustering GRPC API.
+            This value is set on startup by the corresponding environment variable (INTERNAL_API_ADVERTISE_ADDRESS)
+          example: '["192.0.2.1:5710"]'
+          readOnly: true
+          type: string
+        labels:
+          additionalProperties:
+            type: string
+          description: |
+            A set of arbitrary key value labels to apply to the entity.
+          example:
+            env: prod
+            rack: db-1
+          externalDocs:
+            url: https://docs.storageos.com/v2/openapi-help/labels
+          type: object
+        createdAt:
+          description: |
+            The time the entity was created.
+            This timestamp is set by the node that created the entity, and may not be correct if the node's local clock was skewed.
+            This value is for the user's informative purposes only, and correctness is not required.
+            String format is RFC3339.
+          example: 2019-03-10T13:42:42Z
+          format: date-time
+          readOnly: true
+          type: string
+        updatedAt:
+          description: |
+            The time the entity was last updated.
+            This timestamp is set by the node that last updated the entity, and may not be correct if the node's local clock was skewed.
+            This value is for the user's informative purposes only, and correctness is not required.
+            String format is RFC3339.
+          example: 2019-03-29T23:13:13Z
+          format: date-time
+          readOnly: true
+          type: string
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      type: object
+    Namespace:
+      example:
+        createdAt: 2019-03-10T13:42:42Z
+        name: dev
+        id: c5666b58-b805-4215-ab4a-cb094948ccc6
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+        labels:
+          env: prod
+          rack: db-1
+        updatedAt: 2019-03-29T23:13:13Z
+      properties:
+        id:
+          description: |
+            A unique identifier for a namespace. The format of this type is undefined and may change but the defined properties will not change..
+          example: c5666b58-b805-4215-ab4a-cb094948ccc6
+          type: string
+        name:
+          example: dev
+          readOnly: true
+          type: string
+        labels:
+          additionalProperties:
+            type: string
+          description: |
+            A set of arbitrary key value labels to apply to the entity.
+          example:
+            env: prod
+            rack: db-1
+          externalDocs:
+            url: https://docs.storageos.com/v2/openapi-help/labels
+          type: object
+        createdAt:
+          description: |
+            The time the entity was created.
+            This timestamp is set by the node that created the entity, and may not be correct if the node's local clock was skewed.
+            This value is for the user's informative purposes only, and correctness is not required.
+            String format is RFC3339.
+          example: 2019-03-10T13:42:42Z
+          format: date-time
+          readOnly: true
+          type: string
+        updatedAt:
+          description: |
+            The time the entity was last updated.
+            This timestamp is set by the node that last updated the entity, and may not be correct if the node's local clock was skewed.
+            This value is for the user's informative purposes only, and correctness is not required.
+            String format is RFC3339.
+          example: 2019-03-29T23:13:13Z
+          format: date-time
+          readOnly: true
+          type: string
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      type: object
+    PolicyGroup:
+      example:
+        specs:
+        - namespaceID: 251f065a-d89b-4426-a752-5fdd144d00e8
+          resourceType: '*'
+          readOnly: false
+        - namespaceID: 5f009d1f-6618-43c2-9ae4-e699461dda8e
+          resourceType: volume
+          readOnly: true
+        createdAt: 2019-03-10T13:42:42Z
+        name: dev-users
+        id: c5666b58-b805-4215-ab4a-cb094948ccc6
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+        users:
+        - id: 82f297ae-8381-4c09-b9a1-8401c83c418d
+          username: user_a
+        - id: f4bb11d6-594a-4f21-9d1c-d49711a0453e
+          username: user_b
+        - id: 30d3a4dc-971b-4f3e-9b89-5da6fea383ce
+          username: user_c
+        updatedAt: 2019-03-29T23:13:13Z
+      properties:
+        id:
+          description: |
+            A unique identifier for a policy group. The format of this type is undefined and may change but the defined properties will not change..
+          example: c5666b58-b805-4215-ab4a-cb094948ccc6
+          type: string
+        name:
+          example: dev-users
+          type: string
+        users:
+          description: The list of user IDs which this policy group governs.
+          example:
+          - id: 82f297ae-8381-4c09-b9a1-8401c83c418d
+            username: user_a
+          - id: f4bb11d6-594a-4f21-9d1c-d49711a0453e
+            username: user_b
+          - id: 30d3a4dc-971b-4f3e-9b89-5da6fea383ce
+            username: user_c
+          items:
+            $ref: '#/components/schemas/PolicyGroup_users'
+          readOnly: true
+          type: array
+        specs:
+          default: []
+          description: A set of authorisation policies to apply to the policy group.
+          example:
+          - namespaceID: 251f065a-d89b-4426-a752-5fdd144d00e8
+            resourceType: '*'
+            readOnly: false
+          - namespaceID: 5f009d1f-6618-43c2-9ae4-e699461dda8e
+            resourceType: volume
+            readOnly: true
+          items:
+            $ref: '#/components/schemas/_policies__id__specs'
+          nullable: true
+          type: array
+        createdAt:
+          description: |
+            The time the entity was created.
+            This timestamp is set by the node that created the entity, and may not be correct if the node's local clock was skewed.
+            This value is for the user's informative purposes only, and correctness is not required.
+            String format is RFC3339.
+          example: 2019-03-10T13:42:42Z
+          format: date-time
+          readOnly: true
+          type: string
+        updatedAt:
+          description: |
+            The time the entity was last updated.
+            This timestamp is set by the node that last updated the entity, and may not be correct if the node's local clock was skewed.
+            This value is for the user's informative purposes only, and correctness is not required.
+            String format is RFC3339.
+          example: 2019-03-29T23:13:13Z
+          format: date-time
+          readOnly: true
+          type: string
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      type: object
+    Licence:
+      description: |
+        A representation of a cluster's licence properties
+      example:
+        clusterCapacityBytes: 1000000
+        features:
+        - features
+        - features
+        kind: unregistered
+        clusterID: c5666b58-b805-4215-ab4a-cb094948ccc6
+        usedBytes: 42
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+        expiresAt: 2019-03-10T13:42:42Z
+        customerName: Desmond
+      properties:
+        clusterID:
+          description: |
+            A unique identifier for a cluster. The format of this type is undefined and may change but the defined properties will not change.
+          example: c5666b58-b805-4215-ab4a-cb094948ccc6
+          readOnly: true
+          type: string
+        expiresAt:
+          description: |
+            The time after which a licence will no longer be valid
+            This timestamp is set when the licence is created.
+            String format is RFC3339.
+          example: 2019-03-10T13:42:42Z
+          format: date-time
+          readOnly: true
+          type: string
+        clusterCapacityBytes:
+          description: |
+            The allowed provisioning capacity in bytes
+            This value if for the cluster, if provisioning a volume brings the cluster's total provisioned capacity above it the request will fail
+          example: 1000000
+          minimum: 0
+          type: uint64
+        usedBytes:
+          description: |
+            Sum of the size of all volumes in the cluster
+          example: 42
+          type: uint64
+        kind:
+          description: |
+            Denotes which category the licence belongs to
+          example: unregistered
+          type: string
+        customerName:
+          description: |
+            A user friendly reference to the customer
+          example: Desmond
+          type: string
+        features:
+          description: |
+            A list of product features which are enabled by the  licence, subject to the installed version.
+          items:
+            type: string
+          nullable: true
+          type: array
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      type: object
+    AcceptedMessage:
+      example:
+        msg: 'asynchronous request accepted with timeout: 10s'
+      properties:
+        msg:
+          type: string
+      type: object
+    UserList:
+      items:
+        $ref: '#/components/schemas/User'
+      type: array
+    NamespaceList:
+      items:
+        $ref: '#/components/schemas/Namespace'
+      type: array
+    NodeList:
+      items:
+        $ref: '#/components/schemas/Node'
+      type: array
+    PolicyGroupList:
+      items:
+        $ref: '#/components/schemas/PolicyGroup'
+      type: array
+    VolumeList:
+      items:
+        $ref: '#/components/schemas/Volume'
+      type: array
+    AuthUserData:
+      example:
+        username: admin
+        password: supersecret
+      properties:
+        username:
+          type: string
+        password:
+          format: password
+          type: string
+      required:
+      - password
+      - username
+      title: AuthUserData
+      type: object
+    CreateUserData:
+      example:
+        password: turtlesaregreat
+        groups:
+        - 24d5db6f-9738-4f17-a257-b9dd41a35309
+        - 4223b453-4d47-49d5-960f-23fc7a8153ba
+        isAdmin: true
+        username: admin
+      properties:
+        username:
+          example: admin
+          type: string
+        password:
+          default: unchanged
+          description: If not present, the existing password is not changed
+          example: turtlesaregreat
+          format: password
+          type: string
+          writeOnly: true
+        isAdmin:
+          default: false
+          description: |
+            If true, this user is an administrator of the cluster.
+            Administrators bypass the usual authentication checks and are granted access to all resources. Some actions (such as adding a new user) can only be performed by an administrator.
+          example: true
+          type: boolean
+        groups:
+          default: []
+          description: |
+            Defines a set of policy group IDs this user is a member of.
+            Policy groups can be used to logically group users and apply authorisation  policies to all members.
+          example:
+          - 24d5db6f-9738-4f17-a257-b9dd41a35309
+          - 4223b453-4d47-49d5-960f-23fc7a8153ba
+          items:
+            $ref: '#/components/schemas/PolicyGroupID'
+          nullable: true
+          type: array
+      required:
+      - password
+      - username
+      title: CreateUserData
+      type: object
+    UpdateUserData:
+      example:
+        password: turtlesaregreat
+        groups:
+        - 24d5db6f-9738-4f17-a257-b9dd41a35309
+        - 4223b453-4d47-49d5-960f-23fc7a8153ba
+        isAdmin: true
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+      properties:
+        password:
+          default: unchanged
+          description: If not present, the existing password is not changed
+          example: turtlesaregreat
+          format: password
+          type: string
+          writeOnly: true
+        isAdmin:
+          default: false
+          description: |
+            If true, this user is an administrator of the cluster.
+            Administrators bypass the usual authentication checks and are granted access to all resources. Some actions (such as adding a new user) can only be performed by an administrator.
+          example: true
+          type: boolean
+        groups:
+          default: []
+          description: |
+            Defines a set of policy group IDs this user is a member of.
+            Policy groups can be used to logically group users and apply authorisation  policies to all members.
+          example:
+          - 24d5db6f-9738-4f17-a257-b9dd41a35309
+          - 4223b453-4d47-49d5-960f-23fc7a8153ba
+          items:
+            $ref: '#/components/schemas/PolicyGroupID'
+          nullable: true
+          type: array
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      title: UpdateUserData
+      type: object
+    UpdateAuthenticatedUserData:
+      example:
+        password: turtlesaregreat
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+      properties:
+        password:
+          default: unchanged
+          description: If not present, the existing password is not changed
+          example: turtlesaregreat
+          format: password
+          type: string
+          writeOnly: true
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      title: UpdateAuthenticatedUserData
+      type: object
+    CreateNamespaceData:
+      example:
+        name: dev
+        labels:
+          env: prod
+          rack: db-1
+      properties:
+        name:
+          description: |
+            The name of the namespace shown in the CLI and UI
+          example: dev
+          pattern: ^[a-z0-9.\-]{1,253}$
+          type: string
+        labels:
+          additionalProperties:
+            type: string
+          description: |
+            A set of arbitrary key value labels to apply to the entity.
+          example:
+            env: prod
+            rack: db-1
+          externalDocs:
+            url: https://docs.storageos.com/v2/openapi-help/labels
+          type: object
+      title: CreateNamespaceData
+      type: object
+    UpdateNamespaceData:
+      example:
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+        labels:
+          env: prod
+          rack: db-1
+      properties:
+        labels:
+          additionalProperties:
+            type: string
+          description: |
+            A set of arbitrary key value labels to apply to the entity.
+          example:
+            env: prod
+            rack: db-1
+          externalDocs:
+            url: https://docs.storageos.com/v2/openapi-help/labels
+          type: object
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      title: UpdateNamespaceData
+      type: object
+    UpdateNodeData:
+      example:
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+        labels:
+          env: prod
+          rack: db-1
+      properties:
+        labels:
+          additionalProperties:
+            type: string
+          description: |
+            A set of arbitrary key value labels to apply to the entity.
+          example:
+            env: prod
+            rack: db-1
+          externalDocs:
+            url: https://docs.storageos.com/v2/openapi-help/labels
+          type: object
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      title: UpdateNodeData
+      type: object
+    SetComputeOnlyNodeData:
+      example:
+        computeOnly: true
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+      properties:
+        computeOnly:
+          description: |
+            Marks the node's desired configuration  state as compute-only. This will result in the node being avoided for volume placement
+          example: true
+          type: boolean
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      title: SetComputeOnlyNodeData
+      type: object
+    _policies_specs:
+      properties:
+        namespaceID:
+          description: |
+            A unique identifier for a namespace. The format of this type is undefined and may change but the defined properties will not change..
+          example: c5666b58-b805-4215-ab4a-cb094948ccc6
+          type: string
+        resourceType:
+          description: |
+            The resource type this policy grants access to.
+          enum:
+          - '*'
+          - cluster
+          - namespace
+          - node
+          - policy
+          - user
+          - volume
+          example: volume
+          type: string
+        readOnly:
+          default: false
+          description: |
+            If true, disallows requests that attempt to mutate the resource.
+          example: false
+          type: boolean
+    CreatePolicyGroupData:
+      example:
+        specs:
+        - namespaceID: 251f065a-d89b-4426-a752-5fdd144d00e8
+          resourceType: '*'
+          readOnly: false
+        - namespaceID: 5f009d1f-6618-43c2-9ae4-e699461dda8e
+          resourceType: volume
+          readOnly: true
+        name: dev-users
+      properties:
+        name:
+          example: dev-users
+          type: string
+        specs:
+          default: []
+          description: A set of authorisation policies to apply to the policy group.
+          example:
+          - namespaceID: 251f065a-d89b-4426-a752-5fdd144d00e8
+            resourceType: '*'
+            readOnly: false
+          - namespaceID: 5f009d1f-6618-43c2-9ae4-e699461dda8e
+            resourceType: volume
+            readOnly: true
+          items:
+            $ref: '#/components/schemas/_policies_specs'
+          nullable: true
+          type: array
+      title: CreatePolicyGroupData
+      type: object
+    _policies__id__specs:
+      properties:
+        namespaceID:
+          description: |
+            A unique identifier for a namespace. The format of this type is undefined and may change but the defined properties will not change..
+          example: c5666b58-b805-4215-ab4a-cb094948ccc6
+          type: string
+        resourceType:
+          description: |
+            The resource type this policy grants access to.
+          enum:
+          - '*'
+          - volume
+          - policy
+          example: volume
+          type: string
+        readOnly:
+          default: false
+          description: |
+            If true, disallows requests that attempt to mutate the resource.
+          example: false
+          type: boolean
+    UpdatePolicyGroupData:
+      example:
+        specs:
+        - namespaceID: 251f065a-d89b-4426-a752-5fdd144d00e8
+          resourceType: '*'
+          readOnly: false
+        - namespaceID: 5f009d1f-6618-43c2-9ae4-e699461dda8e
+          resourceType: volume
+          readOnly: true
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+      properties:
+        specs:
+          default: []
+          description: A set of authorisation policies to apply to the policy group.
+          example:
+          - namespaceID: 251f065a-d89b-4426-a752-5fdd144d00e8
+            resourceType: '*'
+            readOnly: false
+          - namespaceID: 5f009d1f-6618-43c2-9ae4-e699461dda8e
+            resourceType: volume
+            readOnly: true
+          items:
+            $ref: '#/components/schemas/_policies__id__specs'
+          nullable: true
+          type: array
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      title: UpdatePolicyGroupData
+      type: object
+    CreateVolumeData:
+      example:
+        namespaceID: c5666b58-b805-4215-ab4a-cb094948ccc6
+        name: data
+        description: This volume contains the data for my app
+        fsType: ext4
+        labels:
+          env: prod
+          rack: db-1
+        sizeBytes: 5000
+      properties:
+        namespaceID:
+          description: |
+            A unique identifier for a namespace. The format of this type is undefined and may change but the defined properties will not change..
+          example: c5666b58-b805-4215-ab4a-cb094948ccc6
+          type: string
+        labels:
+          additionalProperties:
+            type: string
+          description: |
+            A set of arbitrary key value labels to apply to the entity.
+          example:
+            env: prod
+            rack: db-1
+          externalDocs:
+            url: https://docs.storageos.com/v2/openapi-help/labels
+          type: object
+        name:
+          description: |
+            The name of the volume shown in the CLI and UI
+          example: data
+          pattern: ^[a-z0-9.\-]{1,253}$
+          type: string
+        fsType:
+          $ref: '#/components/schemas/FsType'
+        description:
+          example: This volume contains the data for my app
+          type: string
+        sizeBytes:
+          description: |
+            A volume's size in bytes
+          example: 5000
+          minimum: 0
+          type: uint64
+      required:
+      - fsType
+      - name
+      - namespaceID
+      - sizeBytes
+      title: CreateVolumeData
+      type: object
+    UpdateVolumeData:
+      example:
+        description: This volume contains the data for my app
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+        labels:
+          env: prod
+          rack: db-1
+      properties:
+        labels:
+          additionalProperties:
+            type: string
+          description: |
+            A set of arbitrary key value labels to apply to the entity.
+          example:
+            env: prod
+            rack: db-1
+          externalDocs:
+            url: https://docs.storageos.com/v2/openapi-help/labels
+          type: object
+        description:
+          example: This volume contains the data for my app
+          type: string
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      title: UpdateVolumeData
+      type: object
+    AttachVolumeData:
+      example:
+        nodeID: c5666b58-b805-4215-ab4a-cb094948ccc6
+      properties:
+        nodeID:
+          description: |
+            A unique identifier for a node. The format of this type is undefined and may change but the defined properties will not change.
+          example: c5666b58-b805-4215-ab4a-cb094948ccc6
+          readOnly: true
+          type: string
+      title: AttachVolumeData
+      type: object
+    AttachNFSVolumeData:
+      properties:
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      title: AttachNFSVolumeData
+      type: object
+    NFSVolumeMountEndpoint:
+      properties:
+        mountEndpoint:
+          default: ""
+          description: |
+            The address to which the NFS server is bound.
+          type: string
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      title: NFSVolumeMountEndpoint
+      type: object
+    NFSVolumeExports:
+      properties:
+        exports:
+          items:
+            $ref: '#/components/schemas/NfsExportConfig'
+          type: array
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      title: NFSVolumeExports
+      type: object
+    SetReplicasRequest:
+      example:
+        replicas: 2
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+      properties:
+        replicas:
+          description: |
+            The number of replicas desired.
+          example: 2
+          maximum: 5
+          minimum: 0
+          type: uint64
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      title: SetReplicasRequest
+      type: object
+    ResizeVolumeRequest:
+      example:
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+        sizeBytes: 5368709000
+      properties:
+        sizeBytes:
+          description: |
+            The desired new size for the volume in  bytes. This value cannot be less than  the current size of the volume.
+          example: 5368709000
+          minimum: 1073742000
+          type: uint64
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      title: ResizeVolumeRequest
+      type: object
+    UpdateClusterData:
+      example:
+        disableVersionCheck: false
+        disableCrashReporting: false
+        logFormat: json
+        logLevel: debug
+        disableTelemetry: false
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+      properties:
+        disableTelemetry:
+          default: false
+          description: |
+            Disables collection of telemetry data across the cluster.
+          example: false
+          type: boolean
+        disableCrashReporting:
+          default: false
+          description: |
+            Disables collection of reports for any fatal crashes across the cluster.
+          example: false
+          type: boolean
+        disableVersionCheck:
+          default: false
+          description: |
+            Disables the mechanism responsible for checking if there is an updated version of StorageOS available for installation.
+          example: false
+          type: boolean
+        logLevel:
+          $ref: '#/components/schemas/LogLevel'
+        logFormat:
+          $ref: '#/components/schemas/LogFormat'
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      title: UpdateClusterData
+      type: object
+    UpdateLicence:
+      example:
+        version: NDI0MjQyNDI0MjQyNDI0MjQy
+        key: key
+      properties:
+        key:
+          description: |
+            A StorageOS product licence key, used to register a cluster. The format of this type is opaque and may change.
+          type: string
+        version:
+          description: |
+            An opaque representation of an entity version at the time it was obtained from the API.
+            All operations that mutate the entity must include this version field in the request unchanged.
+            The format of this type is undefined and may change but the defined properties will not change.
+          example: NDI0MjQyNDI0MjQyNDI0MjQy
+          maxLength: 30
+          type: string
+      title: UpdateLicence
+      type: object
+    NfsAcl_identity:
+      example:
+        identityType: hostname
+        matcher: '*.prod.storageos.com'
+      properties:
+        identityType:
+          description: |
+            The identity type used to identify the nfs client.
+          enum:
+          - cidr
+          - hostname
+          - netgroup
+          example: hostname
+          type: string
+        matcher:
+          description: |
+            NFS identity matcher.
+            For "cidr", this should be a valid CIDR block string such as "10.0.0.0/8".
+            For "hostname", this must be the hostname sent by the client, with ? and * wildcard characters.
+            For netgroup, this must be in the form of "@netgroup" with ? and * wildcard characters.
+          example: '*.prod.storageos.com'
+          type: string
+    NfsAcl_squashConfig:
+      example:
+        uid: ""
+        gid: ""
+        squash: root
+      properties:
+        uid:
+          type: int64
+        gid:
+          type: int64
+        squash:
+          description: "SquashConfig defines the root squashing behaviour. \nWhen\
+            \ a client creates a file, it sends the user UID from the client. If the\
+            \ client is running as root, this sends uid=0. Root squashing allows the\
+            \ NFS administrator to prevent the client from writing as \"root\" to\
+            \ the NFS share, instead mapping the client to a new UID/GID (usually\
+            \ nfsnobody, -2).\n\"none\" performs no UID/GID alterations, using the\
+            \ values sent by the client.\n\"root\" mapps UID & GID 0 to the values\
+            \ specified.\n\"rootuid\" maps UID 0 and a GID of any value to the value\
+            \ specified.\n\"all\" maps changes all UID and GID values to those specified.\n"
+          enum:
+          - none
+          - root
+          - rootuid
+          - all
+          example: root
+          type: string
+    UserSession_allOf_session:
+      properties:
+        expiresInSeconds:
+          description: |
+            The maximum duration which the auth session  will remain valid for in seconds.
+          example: 60
+          minimum: 0
+          type: uint64
+        token:
+          description: |
+            The JWT token for the auth session.
+          type: string
+    UserSession_allOf:
+      properties:
+        session:
+          $ref: '#/components/schemas/UserSession_allOf_session'
+    MasterDeploymentInfo_allOf:
+      properties:
+        health:
+          $ref: '#/components/schemas/MasterHealth'
+    ReplicaDeploymentInfo_allOf:
+      properties:
+        health:
+          $ref: '#/components/schemas/ReplicaHealth'
+        syncProgress:
+          $ref: '#/components/schemas/SyncProgress'
+    PolicyGroup_users:
+      properties:
+        id:
+          description: |
+            A unique identifier for a user. The format of this type is undefined and may change but the defined properties will not change..
+          example: c5666b58-b805-4215-ab4a-cb094948ccc6
+          type: string
+        username:
+          example: admin
+          type: string
+  securitySchemes:
+    jwt:
+      bearerFormat: JWT
+      description: StorageOS uses JSON web tokens for authentication.
+      scheme: bearer
+      type: http

--- a/vendor/github.com/storageos/go-api/v2/go.mod
+++ b/vendor/github.com/storageos/go-api/v2/go.mod
@@ -1,7 +1,9 @@
 module github.com/storageos/go-api/v2
 
+go 1.15
+
 require (
 	github.com/antihax/optional v1.0.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	
+
 )

--- a/vendor/github.com/storageos/go-api/v2/map_error.go
+++ b/vendor/github.com/storageos/go-api/v2/map_error.go
@@ -1,0 +1,165 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/storageos/go-api/v2/api"
+)
+
+// badRequestError indicates that the request made by the client is invalid.
+type badRequestError struct {
+	msg string
+}
+
+func (e badRequestError) Error() string {
+	if e.msg == "" {
+		return "bad request"
+	}
+	return e.msg
+}
+
+func newBadRequestError(msg string) badRequestError {
+	return badRequestError{
+		msg: msg,
+	}
+}
+
+// notFoundError indicates that a resource involved in carrying out the API
+// request was not found.
+type notFoundError struct {
+	msg string
+}
+
+func (e notFoundError) Error() string {
+	if e.msg == "" {
+		return "not found"
+	}
+	return e.msg
+}
+
+func newNotFoundError(msg string) notFoundError {
+	return notFoundError{
+		msg: msg,
+	}
+}
+
+// conflictError indicates that the requested operation could not be carried
+// out due to a conflict between the current state and the desired state.
+type conflictError struct {
+	msg string
+}
+
+func (e conflictError) Error() string {
+	if e.msg == "" {
+		return "conflict"
+	}
+	return e.msg
+}
+
+func newConflictError(msg string) conflictError {
+	return conflictError{
+		msg: msg,
+	}
+}
+
+type openAPIError struct {
+	inner Error
+}
+
+func (e openAPIError) Error() string {
+	return e.inner.Error
+}
+
+func newOpenAPIError(err Error) openAPIError {
+	return openAPIError{
+		inner: err,
+	}
+}
+
+// MapAPIError will given err and its corresponding resp attempt to map the
+// HTTP error to an application level error.
+//
+// err is returned as is when any of the following are true:
+//
+// 	 → resp is nil
+// 	 → err is not a GenericOpenAPIError or the unexported openAPIError
+//
+// Some response codes must be mapped by the caller in order to provide useful
+// application level errors:
+//
+//   → http.StatusBadRequest returns a badRequestError, which must have a 1-to-1
+//   mapping to a context specific application error
+//   → http.StatusNotFound returns a notFoundError, which must have a 1-to-1
+//   mapping to a context specific application error
+//   → http.StatusConflict returns a conflictError which must have a 1-to-1
+//   mapping to a context specific application error
+//
+func MapAPIError(err error, resp *http.Response) error {
+	if resp == nil {
+		return err
+	}
+
+	var details string
+	switch v := err.(type) {
+	case GenericOpenAPIError:
+		switch model := v.Model().(type) {
+		case Error:
+			details = model.Error
+		default:
+			details = fmt.Sprintf("%s", v.Body())
+		}
+	case openAPIError:
+		details = v.Error()
+	default:
+		return err
+	}
+
+	switch resp.StatusCode {
+
+	// 4XX
+	case http.StatusBadRequest:
+		return newBadRequestError(details)
+
+	case http.StatusUnauthorized:
+		return api.NewAuthenticationError(details)
+
+	case http.StatusForbidden:
+		return api.NewUnauthorisedError(details)
+
+	case http.StatusNotFound:
+		return newNotFoundError(details)
+
+	case http.StatusConflict:
+		return newConflictError(details)
+
+	case http.StatusPreconditionFailed:
+		return api.NewStaleWriteError(details)
+
+	case http.StatusUnprocessableEntity:
+		return api.NewInvalidStateTransitionError(details)
+
+	case http.StatusLocked:
+		return api.NewLockedError(details)
+
+	// TODO(CP-3925): This may need changing to present a friendly error, or
+	// it may be done up the call stack.
+	case http.StatusUnavailableForLegalReasons:
+		return api.NewLicenceCapabilityError(details)
+
+	// 5XX
+	case http.StatusInternalServerError:
+		return api.NewServerError(details)
+
+	case http.StatusServiceUnavailable:
+		return api.NewStoreError(details)
+
+	default:
+		// If details were obtained from the error, decorate it - even when
+		// unknown.
+		if details != "" {
+			err = fmt.Errorf("%w: %v", err, details)
+		}
+		return err
+	}
+}

--- a/vendor/github.com/storageos/go-api/v2/map_error.go
+++ b/vendor/github.com/storageos/go-api/v2/map_error.go
@@ -142,8 +142,8 @@ func MapAPIError(err error, resp *http.Response) error {
 	case http.StatusLocked:
 		return api.NewLockedError(details)
 
-	// TODO(CP-3925): This may need changing to present a friendly error, or
-	// it may be done up the call stack.
+	// This may need changing to present a friendly error, or it may be done up
+	// the call stack.
 	case http.StatusUnavailableForLegalReasons:
 		return api.NewLicenceCapabilityError(details)
 

--- a/vendor/github.com/storageos/go-api/v2/model_volume.go
+++ b/vendor/github.com/storageos/go-api/v2/model_volume.go
@@ -49,7 +49,7 @@ func (t Volume) GetName() string {
 
 // GetNamespace returns the volume namespace. 
 func (t Volume) GetNamespace() string {
-	return ""
+	return t.NamespaceID
 }
 
 // GetLabels returns the volume labels.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -129,8 +129,9 @@ github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
-# github.com/storageos/go-api/v2 v2.4.0-alpha6
+# github.com/storageos/go-api/v2 v2.4.0-alpha7
 github.com/storageos/go-api/v2
+github.com/storageos/go-api/v2/api
 # github.com/stretchr/testify v1.6.1
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -129,7 +129,7 @@ github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
-# github.com/storageos/go-api/v2 v2.4.0-alpha7
+# github.com/storageos/go-api/v2 v2.3.1-0.20210129113721-89706365d21f
 github.com/storageos/go-api/v2
 github.com/storageos/go-api/v2/api
 # github.com/stretchr/testify v1.6.1


### PR DESCRIPTION
Maps StorageOS API errors using the same code as the CLI.  This allows us to get full details of the cause of the error in the logs. 
 The error mapping code was added to go-api (separate PR coming)

Adds a new formatter for multierror that works better with json output (no tabs or new lines).

Unwraps some errors prior to returning to avoid stack traces getting written when they're logged by the caller.

