### PR TITLE
Include reserved labels in node label update

### DIFF
--- a/internal/pkg/storageos/node_labels_test.go
+++ b/internal/pkg/storageos/node_labels_test.go
@@ -260,3 +260,164 @@ func TestClient_EnsureNodeLabels(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_EnsureUnreservedNodeLabels(t *testing.T) {
+	tests := []struct {
+		name    string
+		labels  map[string]string
+		prepare func(name string, m *mocks.MockControlPlane)
+	}{
+		{
+			name: "add unrestricted label",
+			labels: map[string]string{
+				"foo": "bar",
+			},
+			prepare: func(name string, m *mocks.MockControlPlane) {
+				nodeId := uuid.New().String()
+				node := api.Node{
+					Id:   nodeId,
+					Name: name,
+				}
+				updateData := api.UpdateNodeData{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				}
+
+				m.EXPECT().ListNodes(gomock.Any()).Return([]api.Node{node}, nil, nil).Times(1)
+				m.EXPECT().UpdateNode(gomock.Any(), nodeId, updateData).Return(api.Node{}, nil, nil).Times(1)
+			},
+		},
+		{
+			name: "change unrestricted label",
+			labels: map[string]string{
+				"foo": "baz",
+			},
+			prepare: func(name string, m *mocks.MockControlPlane) {
+				nodeId := uuid.New().String()
+				node := api.Node{
+					Id:   nodeId,
+					Name: name,
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				}
+				updateData := api.UpdateNodeData{
+					Labels: map[string]string{
+						"foo": "baz",
+					},
+				}
+
+				m.EXPECT().ListNodes(gomock.Any()).Return([]api.Node{node}, nil, nil).Times(1)
+				m.EXPECT().UpdateNode(gomock.Any(), nodeId, updateData).Return(api.Node{}, nil, nil).Times(1)
+			},
+		},
+		{
+			name:   "remove unrestricted label",
+			labels: map[string]string{},
+			prepare: func(name string, m *mocks.MockControlPlane) {
+				nodeId := uuid.New().String()
+				node := api.Node{
+					Id:   nodeId,
+					Name: name,
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				}
+				updateData := api.UpdateNodeData{
+					Labels: map[string]string{},
+				}
+
+				m.EXPECT().ListNodes(gomock.Any()).Return([]api.Node{node}, nil, nil).Times(1)
+				m.EXPECT().UpdateNode(gomock.Any(), nodeId, updateData).Return(api.Node{}, nil, nil).Times(1)
+			},
+		},
+		// Restricted label changes are handled by other Ensure functions.  Just
+		// check no updates are made and no errors when changes are passed.
+		{
+			name: "add restricted label - nil existing labels",
+			labels: map[string]string{
+				storageos.ReservedLabelComputeOnly: "true",
+			},
+			prepare: func(name string, m *mocks.MockControlPlane) {
+				nodeId := uuid.New().String()
+				node := api.Node{
+					Id:   nodeId,
+					Name: name,
+				}
+
+				m.EXPECT().ListNodes(gomock.Any()).Return([]api.Node{node}, nil, nil).Times(1)
+			},
+		},
+		{
+			name: "add restricted label - empty existing labels",
+			labels: map[string]string{
+				storageos.ReservedLabelComputeOnly: "true",
+			},
+			prepare: func(name string, m *mocks.MockControlPlane) {
+				nodeId := uuid.New().String()
+				node := api.Node{
+					Id:     nodeId,
+					Name:   name,
+					Labels: map[string]string{},
+				}
+
+				m.EXPECT().ListNodes(gomock.Any()).Return([]api.Node{node}, nil, nil).Times(1)
+			},
+		},
+		{
+			name: "change restricted label",
+			labels: map[string]string{
+				storageos.ReservedLabelComputeOnly: "true",
+			},
+			prepare: func(name string, m *mocks.MockControlPlane) {
+				nodeId := uuid.New().String()
+				node := api.Node{
+					Id:   nodeId,
+					Name: name,
+					Labels: map[string]string{
+						storageos.ReservedLabelComputeOnly: "false",
+					},
+				}
+
+				m.EXPECT().ListNodes(gomock.Any()).Return([]api.Node{node}, nil, nil).Times(1)
+			},
+		},
+		{
+			name:   "remove unrestricted label",
+			labels: map[string]string{},
+			prepare: func(name string, m *mocks.MockControlPlane) {
+				nodeId := uuid.New().String()
+				node := api.Node{
+					Id:   nodeId,
+					Name: name,
+					Labels: map[string]string{
+						storageos.ReservedLabelComputeOnly: "true",
+					},
+				}
+
+				m.EXPECT().ListNodes(gomock.Any()).Return([]api.Node{node}, nil, nil).Times(1)
+			},
+		},
+	}
+	for _, tt := range tests {
+		var tt = tt
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+			mockCP := mocks.NewMockControlPlane(mockCtrl)
+
+			c := storageos.NewTestAPIClient(mockCP)
+
+			nodeName := "testnode"
+
+			// key := client.ObjectKey{Name: nodeName}
+			if tt.prepare != nil {
+				tt.prepare(nodeName, mockCP)
+			}
+			if err := c.EnsureUnreservedNodeLabels(context.Background(), nodeName, tt.labels); err != nil {
+				t.Errorf("Client.EnsureUnreservedNodeLabels() error = %v, wantErr %v", err, false)
+			}
+		})
+	}
+}

--- a/internal/pkg/storageos/volume_labels_test.go
+++ b/internal/pkg/storageos/volume_labels_test.go
@@ -470,6 +470,8 @@ func TestClient_EnsureUnreservedVolumeLabels(t *testing.T) {
 				m.EXPECT().UpdateVolume(gomock.Any(), nsId, volId, updateData, nil).Return(api.Volume{}, nil, nil).Times(1)
 			},
 		},
+		// Restricted label changes are handled by other Ensure functions.  Just
+		// check no updates are made and no errors when changes are passed.
 		{
 			name: "add restricted label - nil existing labels",
 			labels: map[string]string{


### PR DESCRIPTION
Similar to volumes, the control plane API expects the current reserved labels to be included in the map of labels sent during a node update, and they must have the same value as there are separate API endpoints to update them.
