### PR TITLE
Standardise on ObjectKeys for all API function signatures

### DIFF
--- a/controllers/namespace-delete/controller.go
+++ b/controllers/namespace-delete/controller.go
@@ -38,7 +38,7 @@ func (c Controller) Delete(ctx context.Context, obj client.Object) error {
 	ctx, cancel := context.WithTimeout(ctx, storageos.DefaultRequestTimeout)
 	defer cancel()
 
-	err := c.api.DeleteNamespace(ctx, obj.GetName())
+	err := c.api.DeleteNamespace(ctx, client.ObjectKeyFromObject(obj))
 	if err != nil && err != storageos.ErrNamespaceNotFound {
 		return err
 	}

--- a/controllers/node-delete/controller.go
+++ b/controllers/node-delete/controller.go
@@ -37,7 +37,7 @@ func (c Controller) Delete(ctx context.Context, obj client.Object) error {
 	ctx, cancel := context.WithTimeout(ctx, storageos.DefaultRequestTimeout)
 	defer cancel()
 
-	err := c.api.DeleteNode(ctx, obj.GetName())
+	err := c.api.DeleteNode(ctx, client.ObjectKeyFromObject(obj))
 	if err != nil && err != storageos.ErrNodeNotFound {
 		return err
 	}

--- a/controllers/node-label/controller.go
+++ b/controllers/node-label/controller.go
@@ -39,7 +39,7 @@ func (c Controller) Ensure(ctx context.Context, obj client.Object) error {
 	ctx, cancel := context.WithTimeout(ctx, storageos.DefaultRequestTimeout)
 	defer cancel()
 
-	if err := c.api.EnsureNodeLabels(ctx, obj.GetName(), obj.GetLabels()); err != nil {
+	if err := c.api.EnsureNodeLabels(ctx, client.ObjectKeyFromObject(obj), obj.GetLabels()); err != nil {
 		return err
 	}
 	c.log.Info("node labels applied to storageos", "name", obj.GetName())
@@ -59,7 +59,7 @@ func (c Controller) Diff(ctx context.Context, objs []client.Object) ([]client.Ob
 		return nil, err
 	}
 	for _, obj := range objs {
-		node, ok := nodes[obj.GetName()]
+		node, ok := nodes[client.ObjectKeyFromObject(obj)]
 		if !ok || node == nil {
 			// Ignore nodes not already known to StorageOS.
 			continue

--- a/controllers/node-label/mocks/mock_node_labeller.go
+++ b/controllers/node-label/mocks/mock_node_labeller.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	storageos "github.com/storageos/api-manager/internal/pkg/storageos"
+	types "k8s.io/apimachinery/pkg/types"
 	reflect "reflect"
 )
 
@@ -35,7 +36,7 @@ func (m *MockNodeLabeller) EXPECT() *MockNodeLabellerMockRecorder {
 }
 
 // EnsureNodeLabels mocks base method
-func (m *MockNodeLabeller) EnsureNodeLabels(arg0 context.Context, arg1 string, arg2 map[string]string) error {
+func (m *MockNodeLabeller) EnsureNodeLabels(arg0 context.Context, arg1 types.NamespacedName, arg2 map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureNodeLabels", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -49,10 +50,10 @@ func (mr *MockNodeLabellerMockRecorder) EnsureNodeLabels(arg0, arg1, arg2 interf
 }
 
 // NodeObjects mocks base method
-func (m *MockNodeLabeller) NodeObjects(arg0 context.Context) (map[string]storageos.Object, error) {
+func (m *MockNodeLabeller) NodeObjects(arg0 context.Context) (map[types.NamespacedName]storageos.Object, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NodeObjects", arg0)
-	ret0, _ := ret[0].(map[string]storageos.Object)
+	ret0, _ := ret[0].(map[types.NamespacedName]storageos.Object)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/controllers/node-label/reconciler.go
+++ b/controllers/node-label/reconciler.go
@@ -19,8 +19,8 @@ import (
 // NodeLabeller provides access to update node labels.
 //go:generate mockgen -destination=mocks/mock_node_labeller.go -package=mocks . NodeLabeller
 type NodeLabeller interface {
-	EnsureNodeLabels(ctx context.Context, name string, labels map[string]string) error
-	NodeObjects(ctx context.Context) (map[string]storageos.Object, error)
+	EnsureNodeLabels(ctx context.Context, key client.ObjectKey, labels map[string]string) error
+	NodeObjects(ctx context.Context) (map[client.ObjectKey]storageos.Object, error)
 }
 
 // Reconciler reconciles a Node object by applying labels from the Kubernetes

--- a/controllers/node_delete_test.go
+++ b/controllers/node_delete_test.go
@@ -2,12 +2,10 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"os"
 	"time"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -21,35 +19,29 @@ import (
 
 // SetupNodeDeleteTest will set up a testing environment.  It must be called
 // from each test.
-func SetupNodeDeleteTest(ctx context.Context, createK8sNode bool, isStorageOS bool, gcEnabled bool) *corev1.Node {
-	node := &corev1.Node{}
-
+func SetupNodeDeleteTest(ctx context.Context, createK8sNode bool, isStorageOS bool, gcEnabled bool) client.ObjectKey {
+	var key = client.ObjectKey{Name: "testnode-" + randStringRunes(5)}
 	var cancel func()
 
 	BeforeEach(func() {
 		ctx, cancel = context.WithCancel(ctx)
 
-		*node = corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{Name: "testnode-" + randStringRunes(5)},
-		}
-
-		if isStorageOS {
-			driverMap, err := json.Marshal(map[string]string{
-				nodedelete.DriverName: uuid.New().String(),
-			})
-			Expect(err).NotTo(HaveOccurred(), "failed to marshal csi driver annotation")
-			node.Annotations = map[string]string{
-				nodedelete.DriverAnnotationKey: string(driverMap),
-			}
-		}
-
 		if createK8sNode {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: key.Name},
+			}
+			if isStorageOS {
+				k, v := getCSIAnnotation()
+				node.Annotations = map[string]string{
+					k: v,
+				}
+			}
 			err := k8sClient.Create(ctx, node)
 			Expect(err).NotTo(HaveOccurred(), "failed to create test node")
 		}
 
 		api = storageos.NewMockClient()
-		err := api.AddNode(node.Name)
+		err := api.AddNode(storageos.MockObject{Name: key.Name})
 		Expect(err).NotTo(HaveOccurred(), "failed to create test node in storageos")
 
 		mgr, err := ctrl.NewManager(cfg, ctrl.Options{})
@@ -79,7 +71,7 @@ func SetupNodeDeleteTest(ctx context.Context, createK8sNode bool, isStorageOS bo
 		cancel()
 	})
 
-	return node
+	return key
 }
 
 var _ = Describe("Node Delete controller", func() {
@@ -94,52 +86,65 @@ var _ = Describe("Node Delete controller", func() {
 	ctx := context.Background()
 
 	Context("When deleting a k8s Node with the StorageOS driver registered", func() {
-		node := SetupNodeDeleteTest(ctx, true, true, false)
+		key := SetupNodeDeleteTest(ctx, true, true, false)
 		It("Should delete the StorageOS Node", func() {
+			By("Confirming Node exists in k8s")
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, key, &node)).Should(Succeed())
+
 			By("By deleting the k8s Node")
-			Expect(k8sClient.Delete(ctx, node)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, &node)).Should(Succeed())
 
 			By("Expecting StorageOS Node to be deleted")
 			Eventually(func() bool {
-				return api.NodeExists(node.Name)
+				return api.NodeExists(key)
 			}, timeout, interval).Should(BeFalse())
 		})
 	})
 
 	Context("When deleting a k8s Node and the StorageOS node has already been deleted", func() {
-		node := SetupNodeDeleteTest(ctx, true, true, false)
+		key := SetupNodeDeleteTest(ctx, true, true, false)
 		It("Should not fail", func() {
 			By("By causing the StorageOS Node delete to fail with a 404")
 			api.DeleteNodeErr = storageos.ErrNodeNotFound
 
+			By("Confirming Node exists in k8s")
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, key, &node)).Should(Succeed())
+
 			By("By deleting the k8s Node")
-			Expect(k8sClient.Delete(ctx, node)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, &node)).Should(Succeed())
 
 			By("Expecting StorageOS Delete Node to be called only once")
 			Eventually(func() int {
-				return api.DeleteNodeCallCount[node.Name]
+				return api.DeleteNodeCallCount[key]
 			}, timeout, interval).Should(Equal(1))
 			Consistently(func() int {
-				return api.DeleteNodeCallCount[node.Name]
+				return api.DeleteNodeCallCount[key]
 			}, duration, interval).Should(Equal(1))
 		})
 	})
 
 	Context("When deleting a k8s Node without the StorageOS driver registration", func() {
-		node := SetupNodeDeleteTest(ctx, true, false, false)
+		key := SetupNodeDeleteTest(ctx, true, false, false)
 		It("Should not delete the StorageOS Node", func() {
+
+			By("Confirming Node exists in k8s")
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, key, &node)).Should(Succeed())
+
 			By("By deleting the k8s Node")
-			Expect(k8sClient.Delete(ctx, node)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, &node)).Should(Succeed())
 
 			By("Expecting StorageOS Node to not be deleted")
 			Consistently(func() bool {
-				return api.NodeExists(node.Name)
+				return api.NodeExists(key)
 			}, duration, interval).Should(BeTrue())
 		})
 	})
 
 	Context("When deleting a k8s Node with a malformed StorageOS driver registration", func() {
-		node := SetupNodeDeleteTest(ctx, true, false, false)
+		key := SetupNodeDeleteTest(ctx, true, false, false)
 		It("Should not delete the StorageOS Node", func() {
 			// Skip test if not running in envtest.  k8s will disallow the
 			// malformed annotation.
@@ -147,49 +152,57 @@ var _ = Describe("Node Delete controller", func() {
 				Skip("k8s will reject malformed annotation")
 			}
 
+			By("Confirming Node exists in k8s")
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, key, &node)).Should(Succeed())
+
 			By("By setting an invalid annotation")
 			node.Annotations = map[string]string{
 				nodedelete.DriverAnnotationKey: "{\"csi.storageos.com\":}",
 			}
-			Expect(k8sClient.Update(ctx, node, &client.UpdateOptions{})).Should(Succeed())
+			Expect(k8sClient.Update(ctx, &node, &client.UpdateOptions{})).Should(Succeed())
 
 			By("By deleting the k8s Node")
-			Expect(k8sClient.Delete(ctx, node)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, &node)).Should(Succeed())
 
 			By("Expecting StorageOS Node to not be deleted")
 			Consistently(func() bool {
-				return api.NodeExists(node.Name)
+				return api.NodeExists(key)
 			}, duration, interval).Should(BeTrue())
 		})
 	})
 
 	Context("When deleting a k8s Node that still has volumes", func() {
-		node := SetupNodeDeleteTest(ctx, true, true, false)
+		key := SetupNodeDeleteTest(ctx, true, true, false)
 		It("Should not delete the StorageOS Node", func() {
 			By("By causing the StorageOS Node delete to fail")
 			api.DeleteNodeErr = errors.New("delete failed")
 
+			By("Confirming Node exists in k8s")
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, key, &node)).Should(Succeed())
+
 			By("By deleting the k8s Node")
-			Expect(k8sClient.Delete(ctx, node)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, &node)).Should(Succeed())
 
 			By("Expecting StorageOS Node to not be deleted")
 			Consistently(func() bool {
-				return api.NodeExists(node.Name)
+				return api.NodeExists(key)
 			}, duration, interval).Should(BeTrue())
 
 			By("Expecting StorageOS Delete Node to be called multiple times")
 			Eventually(func() int {
-				return api.DeleteNodeCallCount[node.Name]
+				return api.DeleteNodeCallCount[key]
 			}, timeout, interval).Should(BeNumerically(">", 1))
 		})
 	})
 
 	Context("When starting after a k8s Node has been deleted but is still in StorageOS", func() {
-		node := SetupNodeDeleteTest(ctx, false, true, true)
+		key := SetupNodeDeleteTest(ctx, false, true, true)
 		It("The garbage collector should delete the StorageOS Node", func() {
 			By("Expecting StorageOS Node to be deleted")
 			Eventually(func() bool {
-				return api.NodeExists(node.Name)
+				return api.NodeExists(key)
 			}, timeout, interval).Should(BeFalse())
 		})
 	})

--- a/controllers/node_label_sync_test.go
+++ b/controllers/node_label_sync_test.go
@@ -21,33 +21,33 @@ import (
 
 // SetupNodeLabelSyncTest will set up a testing environment.  It must be
 // called from each test.
-func SetupNodeLabelSyncTest(ctx context.Context, isStorageOS bool, createLabels map[string]string, gcEnabled bool) *corev1.Node {
-	node := &corev1.Node{}
-
+func SetupNodeLabelSyncTest(ctx context.Context, isStorageOS bool, createLabels map[string]string, gcEnabled bool) client.ObjectKey {
+	var node *corev1.Node
+	var key = client.ObjectKey{Name: "testnode-" + randStringRunes(5)}
 	var cancel func()
 
 	BeforeEach(func() {
 		ctx, cancel = context.WithCancel(ctx)
 
-		*node = corev1.Node{
+		node = &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   "testnode-" + randStringRunes(5),
+				Name:   key.Name,
 				Labels: createLabels,
 			},
 		}
-
 		if isStorageOS {
-			k, v := getCSIAnnotation()
-			node.Annotations = map[string]string{
-				k: v,
+			if isStorageOS {
+				k, v := getCSIAnnotation()
+				node.Annotations = map[string]string{
+					k: v,
+				}
 			}
 		}
-
 		err := k8sClient.Create(ctx, node)
 		Expect(err).NotTo(HaveOccurred(), "failed to create test node")
 
 		api = storageos.NewMockClient()
-		err = api.AddNode(node.Name)
+		err = api.AddNode(storageos.MockObject{Name: key.Name})
 		Expect(err).NotTo(HaveOccurred(), "failed to create test node in storageos")
 
 		mgr, err := ctrl.NewManager(cfg, ctrl.Options{})
@@ -77,7 +77,7 @@ func SetupNodeLabelSyncTest(ctx context.Context, isStorageOS bool, createLabels 
 		cancel()
 	})
 
-	return node
+	return key
 }
 
 // getCSIAnnotation is a helper to return a valid StorageOS CSI Driver annotation.
@@ -113,17 +113,21 @@ var _ = Describe("Node Label controller", func() {
 	ctx := context.Background()
 
 	Context("When adding unreserved labels", func() {
-		node := SetupNodeLabelSyncTest(ctx, true, nil, false)
+		key := SetupNodeLabelSyncTest(ctx, true, nil, false)
 		It("Should sync labels to StorageOS Node", func() {
+			By("Confirming Node exists in k8s")
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, key, &node)).Should(Succeed())
+
 			By("By adding unreserved labels to k8s Node")
 			node.SetLabels(unreservedLabels)
 			Eventually(func() error {
-				return k8sClient.Update(ctx, node)
+				return k8sClient.Update(ctx, &node)
 			}, timeout, interval).Should(Succeed())
 
 			By("Expecting StorageOS Node labels to match")
 			Eventually(func() map[string]string {
-				labels, err := api.GetNodeLabels(node.Name)
+				labels, err := api.GetNodeLabels(key)
 				if err != nil {
 					return nil
 				}
@@ -133,17 +137,21 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding reserved labels", func() {
-		node := SetupNodeLabelSyncTest(ctx, true, nil, false)
+		key := SetupNodeLabelSyncTest(ctx, true, nil, false)
 		It("Should sync labels to StorageOS Node", func() {
+			By("Confirming Node exists in k8s")
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, key, &node)).Should(Succeed())
+
 			By("By adding reserved labels to k8s Node")
 			node.SetLabels(reservedLabels)
 			Eventually(func() error {
-				return k8sClient.Update(ctx, node)
+				return k8sClient.Update(ctx, &node)
 			}, timeout, interval).Should(Succeed())
 
 			By("Expecting StorageOS Node labels to match")
 			Eventually(func() map[string]string {
-				labels, err := api.GetNodeLabels(node.Name)
+				labels, err := api.GetNodeLabels(key)
 				if err != nil {
 					return nil
 				}
@@ -153,17 +161,21 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding mixed labels", func() {
-		node := SetupNodeLabelSyncTest(ctx, true, nil, false)
+		key := SetupNodeLabelSyncTest(ctx, true, nil, false)
 		It("Should sync labels to StorageOS Node", func() {
+			By("Confirming Node exists in k8s")
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, key, &node)).Should(Succeed())
+
 			By("By adding mixed labels to k8s Node")
 			node.SetLabels(mixedLabels)
 			Eventually(func() error {
-				return k8sClient.Update(ctx, node)
+				return k8sClient.Update(ctx, &node)
 			}, timeout, interval).Should(Succeed())
 
 			By("Expecting StorageOS Node labels to match")
 			Eventually(func() map[string]string {
-				labels, err := api.GetNodeLabels(node.Name)
+				labels, err := api.GetNodeLabels(key)
 				if err != nil {
 					return nil
 				}
@@ -173,8 +185,12 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding unrecognised reserved labels", func() {
-		node := SetupNodeLabelSyncTest(ctx, true, nil, false)
+		key := SetupNodeLabelSyncTest(ctx, true, nil, false)
 		It("Should only sync recognised labels to StorageOS Node", func() {
+			By("Confirming Node exists in k8s")
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, key, &node)).Should(Succeed())
+
 			By("By adding unrecognised reserved labels to k8s Node")
 			labels := map[string]string{}
 			for k, v := range unreservedLabels {
@@ -183,12 +199,12 @@ var _ = Describe("Node Label controller", func() {
 			labels[storageos.ReservedLabelPrefix+"unrecognised"] = "true"
 			node.SetLabels(labels)
 			Eventually(func() error {
-				return k8sClient.Update(ctx, node)
+				return k8sClient.Update(ctx, &node)
 			}, timeout, interval).Should(Succeed())
 
 			By("Expecting StorageOS Node labels to match other labels")
 			Eventually(func() map[string]string {
-				labels, err := api.GetNodeLabels(node.Name)
+				labels, err := api.GetNodeLabels(key)
 				if err != nil {
 					return nil
 				}
@@ -198,20 +214,24 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding computeonly label", func() {
-		node := SetupNodeLabelSyncTest(ctx, true, nil, false)
+		key := SetupNodeLabelSyncTest(ctx, true, nil, false)
 		It("Should sync labels to StorageOS Node", func() {
+			By("Confirming Node exists in k8s")
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, key, &node)).Should(Succeed())
+
 			By("By adding computeonly label to k8s Node")
 			labels := map[string]string{
 				storageos.ReservedLabelComputeOnly: "true",
 			}
 			node.SetLabels(labels)
 			Eventually(func() error {
-				return k8sClient.Update(ctx, node)
+				return k8sClient.Update(ctx, &node)
 			}, timeout, interval).Should(Succeed())
 
 			By("Expecting StorageOS Node labels to match")
 			Eventually(func() map[string]string {
-				labels, err := api.GetNodeLabels(node.Name)
+				labels, err := api.GetNodeLabels(key)
 				if err != nil {
 					return nil
 				}
@@ -221,17 +241,21 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding and removing mixed labels", func() {
-		node := SetupNodeLabelSyncTest(ctx, true, nil, false)
+		key := SetupNodeLabelSyncTest(ctx, true, nil, false)
 		It("Should sync labels to StorageOS Node", func() {
+			By("Confirming Node exists in k8s")
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, key, &node)).Should(Succeed())
+
 			By("By adding labels to k8s Node")
 			node.SetLabels(mixedLabels)
 			Eventually(func() error {
-				return k8sClient.Update(ctx, node)
+				return k8sClient.Update(ctx, &node)
 			}, timeout, interval).Should(Succeed())
 
 			By("Expecting StorageOS Node labels to match")
 			Eventually(func() map[string]string {
-				labels, err := api.GetNodeLabels(node.Name)
+				labels, err := api.GetNodeLabels(key)
 				if err != nil {
 					return nil
 				}
@@ -241,12 +265,12 @@ var _ = Describe("Node Label controller", func() {
 			By("By removing labels from k8s Node")
 			node.SetLabels(map[string]string{})
 			Eventually(func() error {
-				return k8sClient.Update(ctx, node)
+				return k8sClient.Update(ctx, &node)
 			}, timeout, interval).Should(Succeed())
 
 			By("Expecting StorageOS Node labels to match")
 			Eventually(func() map[string]string {
-				labels, err := api.GetNodeLabels(node.Name)
+				labels, err := api.GetNodeLabels(key)
 				if err != nil {
 					return nil
 				}
@@ -256,8 +280,12 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding computeonly label and the StorageOS API returns an error", func() {
-		node := SetupNodeLabelSyncTest(ctx, true, nil, false)
+		key := SetupNodeLabelSyncTest(ctx, true, nil, false)
 		It("Should not sync labels to StorageOS Node", func() {
+			By("Confirming Node exists in k8s")
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, key, &node)).Should(Succeed())
+
 			By("Setting API to return error")
 			api.EnsureNodeLabelsErr = errors.New("fake error")
 
@@ -267,12 +295,12 @@ var _ = Describe("Node Label controller", func() {
 			}
 			node.SetLabels(labels)
 			Eventually(func() error {
-				return k8sClient.Update(ctx, node)
+				return k8sClient.Update(ctx, &node)
 			}, timeout, interval).Should(Succeed())
 
 			By("Expecting StorageOS Node labels to be empty")
 			Eventually(func() map[string]string {
-				labels, err := api.GetNodeLabels(node.Name)
+				labels, err := api.GetNodeLabels(key)
 				if err != nil {
 					return nil
 				}
@@ -282,17 +310,21 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding labels on a k8s Node without the StorageOS driver registration", func() {
-		node := SetupNodeLabelSyncTest(ctx, false, nil, false)
+		key := SetupNodeLabelSyncTest(ctx, false, nil, false)
 		It("Should not sync labels to StorageOS Node", func() {
+			By("Confirming Node exists in k8s")
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, key, &node)).Should(Succeed())
+
 			By("By adding labels to k8s Node")
 			node.SetLabels(unreservedLabels)
 			Eventually(func() error {
-				return k8sClient.Update(ctx, node)
+				return k8sClient.Update(ctx, &node)
 			}, timeout, interval).Should(Succeed())
 
 			By("Expecting StorageOS Node labels not to match")
 			Consistently(func() map[string]string {
-				labels, err := api.GetNodeLabels(node.Name)
+				labels, err := api.GetNodeLabels(key)
 				if err != nil {
 					return nil
 				}
@@ -302,23 +334,27 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding labels a k8s Node with a malformed StorageOS driver registration", func() {
-		node := SetupNodeLabelSyncTest(ctx, false, nil, false)
+		key := SetupNodeLabelSyncTest(ctx, false, nil, false)
 		It("Should not sync labels to StorageOS Node", func() {
+			By("Confirming Node exists in k8s")
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, key, &node)).Should(Succeed())
+
 			By("By setting an invalid annotation")
 			node.Annotations = map[string]string{
 				annotation.DriverAnnotationKey: "{\"csi.storageos.com\":}",
 			}
-			Expect(k8sClient.Update(ctx, node, &client.UpdateOptions{})).Should(Succeed())
+			Expect(k8sClient.Update(ctx, &node, &client.UpdateOptions{})).Should(Succeed())
 
 			By("By adding label to k8s Node")
 			node.SetLabels(unreservedLabels)
 			Eventually(func() error {
-				return k8sClient.Update(ctx, node)
+				return k8sClient.Update(ctx, &node)
 			}, timeout, interval).Should(Succeed())
 
 			By("Expecting StorageOS Node labels not to match")
 			Consistently(func() map[string]string {
-				labels, err := api.GetNodeLabels(node.Name)
+				labels, err := api.GetNodeLabels(key)
 				if err != nil {
 					return nil
 				}
@@ -328,11 +364,15 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When adding the StorageOS driver registration to a node with existing labels", func() {
-		node := SetupNodeLabelSyncTest(ctx, false, mixedLabels, false)
+		key := SetupNodeLabelSyncTest(ctx, false, mixedLabels, false)
 		It("Should sync labels to StorageOS Node", func() {
+			By("Confirming Node exists in k8s")
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, key, &node)).Should(Succeed())
+
 			By("Expecting StorageOS Node labels to be empty")
 			Consistently(func() map[string]string {
-				labels, err := api.GetNodeLabels(node.Name)
+				labels, err := api.GetNodeLabels(key)
 				if err != nil {
 					return nil
 				}
@@ -344,11 +384,11 @@ var _ = Describe("Node Label controller", func() {
 			node.Annotations = map[string]string{
 				k: v,
 			}
-			Expect(k8sClient.Update(ctx, node, &client.UpdateOptions{})).Should(Succeed())
+			Expect(k8sClient.Update(ctx, &node, &client.UpdateOptions{})).Should(Succeed())
 
 			By("Expecting StorageOS Node labels to match")
 			Eventually(func() map[string]string {
-				labels, err := api.GetNodeLabels(node.Name)
+				labels, err := api.GetNodeLabels(key)
 				if err != nil {
 					return nil
 				}
@@ -358,11 +398,15 @@ var _ = Describe("Node Label controller", func() {
 	})
 
 	Context("When starting after a k8s Node with labels has been created", func() {
-		node := SetupNodeLabelSyncTest(ctx, true, mixedLabels, true)
+		key := SetupNodeLabelSyncTest(ctx, true, mixedLabels, true)
 		It("The resync should update the StorageOS Node", func() {
+			By("Confirming Node exists in k8s")
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, key, &node)).Should(Succeed())
+
 			By("Expecting StorageOS Node labels to match")
 			Eventually(func() map[string]string {
-				labels, err := api.GetNodeLabels(node.Name)
+				labels, err := api.GetNodeLabels(key)
 				if err != nil {
 					return nil
 				}

--- a/internal/pkg/storageos/mock_client.go
+++ b/internal/pkg/storageos/mock_client.go
@@ -107,7 +107,7 @@ func (c *MockClient) AddNamespace(key client.ObjectKey) error {
 	return nil
 }
 
-// NamespaceExists returns true if the naemspace exists.
+// NamespaceExists returns true if the namespace exists.
 func (c *MockClient) NamespaceExists(key client.ObjectKey) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -132,7 +132,7 @@ func (c *MockClient) DeleteNamespace(ctx context.Context, key client.ObjectKey) 
 	return nil
 }
 
-// NodeObjects returns a map of nodes objects, keyed on object key.
+// NodeObjects returns a map of nodes objects, indexed on object key.
 func (c *MockClient) NodeObjects(ctx context.Context) (map[client.ObjectKey]Object, error) {
 	if c.NodeObjectsErr != nil {
 		return nil, c.NodeObjectsErr
@@ -247,7 +247,7 @@ func (c *MockClient) GetVolume(key client.ObjectKey) (Object, error) {
 	return obj, nil
 }
 
-// VolumeObjects returns a map of volume objects, keyed on NamespacedName.
+// VolumeObjects returns a map of volume objects, indexed on object key.
 func (c *MockClient) VolumeObjects(ctx context.Context) (map[client.ObjectKey]Object, error) {
 	if c.ListNodesErr != nil {
 		return nil, c.ListNodesErr

--- a/internal/pkg/storageos/mock_client.go
+++ b/internal/pkg/storageos/mock_client.go
@@ -48,13 +48,13 @@ func (m MockObject) GetLabels() map[string]string {
 // MockClient provides a test interface to the StorageOS api.
 type MockClient struct {
 	sharedvols               map[string]*SharedVolume
-	namespaces               map[string]Object
-	nodes                    map[string]Object
+	namespaces               map[client.ObjectKey]Object
+	nodes                    map[client.ObjectKey]Object
 	volumes                  map[client.ObjectKey]Object
 	nodeLabels               map[string]string
 	mu                       sync.RWMutex
-	DeleteNamespaceCallCount map[string]int
-	DeleteNodeCallCount      map[string]int
+	DeleteNamespaceCallCount map[client.ObjectKey]int
+	DeleteNodeCallCount      map[client.ObjectKey]int
 	ListNamespacesErr        error
 	DeleteNamespaceErr       error
 	GetNodeErr               error
@@ -75,12 +75,12 @@ type MockClient struct {
 func NewMockClient() *MockClient {
 	return &MockClient{
 		sharedvols:               make(map[string]*SharedVolume),
-		namespaces:               make(map[string]Object),
-		nodes:                    make(map[string]Object),
+		namespaces:               make(map[client.ObjectKey]Object),
+		nodes:                    make(map[client.ObjectKey]Object),
 		volumes:                  make(map[client.ObjectKey]Object),
 		nodeLabels:               make(map[string]string),
-		DeleteNamespaceCallCount: make(map[string]int),
-		DeleteNodeCallCount:      make(map[string]int),
+		DeleteNamespaceCallCount: make(map[client.ObjectKey]int),
+		DeleteNodeCallCount:      make(map[client.ObjectKey]int),
 		mu:                       sync.RWMutex{},
 	}
 }
@@ -100,40 +100,40 @@ func (c *MockClient) ListNamespaces(ctx context.Context) ([]Object, error) {
 }
 
 // AddNamespace adds a namespace to the StorageOS cluster.
-func (c *MockClient) AddNamespace(name string) error {
+func (c *MockClient) AddNamespace(key client.ObjectKey) error {
 	c.mu.Lock()
-	c.namespaces[name] = MockObject{Name: name}
+	c.namespaces[key] = MockObject{Name: key.Name}
 	c.mu.Unlock()
 	return nil
 }
 
 // NamespaceExists returns true if the naemspace exists.
-func (c *MockClient) NamespaceExists(name string) bool {
+func (c *MockClient) NamespaceExists(key client.ObjectKey) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	if _, ok := c.namespaces[name]; ok {
+	if _, ok := c.namespaces[key]; ok {
 		return true
 	}
 	return false
 }
 
 // DeleteNamespace removes a namespace from the StorageOS cluster.
-func (c *MockClient) DeleteNamespace(ctx context.Context, name string) error {
-	c.DeleteNamespaceCallCount[name]++
+func (c *MockClient) DeleteNamespace(ctx context.Context, key client.ObjectKey) error {
+	c.DeleteNamespaceCallCount[key]++
 	if c.DeleteNamespaceErr != nil {
 		return c.DeleteNamespaceErr
 	}
-	if !c.NamespaceExists(name) {
+	if !c.NamespaceExists(key) {
 		return ErrNamespaceNotFound
 	}
 	c.mu.Lock()
-	delete(c.namespaces, name)
+	delete(c.namespaces, key)
 	c.mu.Unlock()
 	return nil
 }
 
-// NodeObjects returns a map of nodes objects, keyed on node name.
-func (c *MockClient) NodeObjects(ctx context.Context) (map[string]Object, error) {
+// NodeObjects returns a map of nodes objects, keyed on object key.
+func (c *MockClient) NodeObjects(ctx context.Context) (map[client.ObjectKey]Object, error) {
 	if c.NodeObjectsErr != nil {
 		return nil, c.NodeObjectsErr
 	}
@@ -157,40 +157,40 @@ func (c *MockClient) ListNodes(ctx context.Context) ([]Object, error) {
 }
 
 // AddNode adds a node to the StorageOS cluster.
-func (c *MockClient) AddNode(name string) error {
+func (c *MockClient) AddNode(obj Object) error {
 	c.mu.Lock()
-	c.nodes[name] = MockObject{Name: name}
+	c.nodes[ObjectKeyFromObject(obj)] = obj
 	c.mu.Unlock()
 	return nil
 }
 
 // NodeExists returns true if the node exists.
-func (c *MockClient) NodeExists(name string) bool {
+func (c *MockClient) NodeExists(key client.ObjectKey) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	if _, ok := c.nodes[name]; ok {
+	if _, ok := c.nodes[key]; ok {
 		return true
 	}
 	return false
 }
 
 // DeleteNode removes a node from the StorageOS cluster.
-func (c *MockClient) DeleteNode(ctx context.Context, name string) error {
-	c.DeleteNodeCallCount[name]++
+func (c *MockClient) DeleteNode(ctx context.Context, key client.ObjectKey) error {
+	c.DeleteNodeCallCount[key]++
 	if c.DeleteNodeErr != nil {
 		return c.DeleteNodeErr
 	}
-	if !c.NodeExists(name) {
+	if !c.NodeExists(key) {
 		return ErrNodeNotFound
 	}
 	c.mu.Lock()
-	delete(c.nodes, name)
+	delete(c.nodes, key)
 	c.mu.Unlock()
 	return nil
 }
 
 // EnsureNodeLabels applies a set of labels to the StorageOS node.
-func (c *MockClient) EnsureNodeLabels(ctx context.Context, name string, labels map[string]string) error {
+func (c *MockClient) EnsureNodeLabels(ctx context.Context, key client.ObjectKey, labels map[string]string) error {
 	if c.EnsureNodeLabelsErr != nil {
 		return c.EnsureNodeLabelsErr
 	}
@@ -216,7 +216,7 @@ func (c *MockClient) EnsureNodeLabels(ctx context.Context, name string, labels m
 }
 
 // GetNodeLabels retrieves the set of labels.
-func (c *MockClient) GetNodeLabels(name string) (map[string]string, error) {
+func (c *MockClient) GetNodeLabels(key client.ObjectKey) (map[string]string, error) {
 	if c.GetNodeLabelsErr != nil {
 		return nil, c.GetNodeLabelsErr
 	}
@@ -355,11 +355,11 @@ func (c *MockClient) Delete(id string, namespace string) {
 func (c *MockClient) Reset() {
 	c.mu.Lock()
 	c.sharedvols = make(map[string]*SharedVolume)
-	c.namespaces = make(map[string]Object)
-	c.nodes = make(map[string]Object)
+	c.namespaces = make(map[client.ObjectKey]Object)
+	c.nodes = make(map[client.ObjectKey]Object)
 	c.nodeLabels = make(map[string]string)
-	c.DeleteNamespaceCallCount = make(map[string]int)
-	c.DeleteNodeCallCount = make(map[string]int)
+	c.DeleteNamespaceCallCount = make(map[client.ObjectKey]int)
+	c.DeleteNodeCallCount = make(map[client.ObjectKey]int)
 	c.ListNamespacesErr = nil
 	c.DeleteNamespaceErr = nil
 	c.ListNodesErr = nil

--- a/internal/pkg/storageos/mocks/mock_namespace_deleter.go
+++ b/internal/pkg/storageos/mocks/mock_namespace_deleter.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	storageos "github.com/storageos/api-manager/internal/pkg/storageos"
+	types "k8s.io/apimachinery/pkg/types"
 	reflect "reflect"
 )
 
@@ -35,7 +36,7 @@ func (m *MockNamespaceDeleter) EXPECT() *MockNamespaceDeleterMockRecorder {
 }
 
 // DeleteNamespace mocks base method
-func (m *MockNamespaceDeleter) DeleteNamespace(arg0 context.Context, arg1 string) error {
+func (m *MockNamespaceDeleter) DeleteNamespace(arg0 context.Context, arg1 types.NamespacedName) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteNamespace", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/internal/pkg/storageos/mocks/mock_node_deleter.go
+++ b/internal/pkg/storageos/mocks/mock_node_deleter.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	storageos "github.com/storageos/api-manager/internal/pkg/storageos"
+	types "k8s.io/apimachinery/pkg/types"
 	reflect "reflect"
 )
 
@@ -35,7 +36,7 @@ func (m *MockNodeDeleter) EXPECT() *MockNodeDeleterMockRecorder {
 }
 
 // DeleteNode mocks base method
-func (m *MockNodeDeleter) DeleteNode(arg0 context.Context, arg1 string) error {
+func (m *MockNodeDeleter) DeleteNode(arg0 context.Context, arg1 types.NamespacedName) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteNode", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/internal/pkg/storageos/namespace.go
+++ b/internal/pkg/storageos/namespace.go
@@ -68,7 +68,7 @@ func (c *Client) DeleteNamespace(ctx context.Context, key client.ObjectKey) erro
 
 	ctx = c.AddToken(ctx)
 
-	ns, err := c.getNamespaceByName(ctx, key)
+	ns, err := c.getNamespace(ctx, key)
 	if err != nil {
 		return observeErr(err)
 	}
@@ -89,10 +89,9 @@ func (c *Client) DeleteNamespace(ctx context.Context, key client.ObjectKey) erro
 	return nil
 }
 
-// getNamespaceByName returns the StorageOS namespace object matching the name,
+// getNamespace returns the StorageOS namespace object matching the key,
 // if any.
-// TODO: Merge with getNamespace() and accept a key.
-func (c *Client) getNamespaceByName(ctx context.Context, key client.ObjectKey) (*api.Namespace, error) {
+func (c *Client) getNamespace(ctx context.Context, key client.ObjectKey) (*api.Namespace, error) {
 	namespaces, resp, err := c.api.ListNamespaces(ctx)
 	if err != nil {
 		return nil, api.MapAPIError(err, resp)

--- a/internal/pkg/storageos/node_labels.go
+++ b/internal/pkg/storageos/node_labels.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
-	"github.com/storageos/api-manager/internal/pkg/storageos/metrics"
 	api "github.com/storageos/go-api/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/storageos/api-manager/internal/pkg/storageos/metrics"
 )
 
 // EnsureNodeLabels applies a set of labels to a StorageOS node.
@@ -19,7 +21,7 @@ import (
 // individual API endpoints to ensure that they are applied atomically.
 //
 // Unreserved labels are copied as a blob and are not evaluated.
-func (c *Client) EnsureNodeLabels(ctx context.Context, name string, labels map[string]string) error {
+func (c *Client) EnsureNodeLabels(ctx context.Context, key client.ObjectKey, labels map[string]string) error {
 	var unreservedLabels = make(map[string]string)
 	var computeOnly = false
 	var err error
@@ -45,12 +47,12 @@ func (c *Client) EnsureNodeLabels(ctx context.Context, name string, labels map[s
 
 	// Apply reserved labels.  Labels that have been removed or have been
 	// changed to an invalid value will get their default re-applied.
-	if err := c.EnsureComputeOnly(ctx, name, computeOnly); err != nil && err != ErrNodeNotFound {
+	if err := c.EnsureComputeOnly(ctx, key, computeOnly); err != nil && err != ErrNodeNotFound {
 		errs = multierror.Append(errs, err)
 	}
 
 	// Apply unreserved labels as a blob, removing any that are no longer set.
-	if err := c.EnsureUnreservedNodeLabels(ctx, name, unreservedLabels); err != nil && err != ErrNodeNotFound {
+	if err := c.EnsureUnreservedNodeLabels(ctx, key, unreservedLabels); err != nil && err != ErrNodeNotFound {
 		errs = multierror.Append(errs, err)
 	}
 
@@ -60,7 +62,7 @@ func (c *Client) EnsureNodeLabels(ctx context.Context, name string, labels map[s
 // EnsureUnreservedNodeLabels applies a set of labels to the StorageOS node if different.
 // Existing labels will be overwritten.  The set of labels must not include
 // StorageOS reserved labels.
-func (c *Client) EnsureUnreservedNodeLabels(ctx context.Context, name string, labels map[string]string) error {
+func (c *Client) EnsureUnreservedNodeLabels(ctx context.Context, key client.ObjectKey, labels map[string]string) error {
 	funcName := "ensure_unreserved_node_labels"
 	start := time.Now()
 	defer func() {
@@ -77,7 +79,7 @@ func (c *Client) EnsureUnreservedNodeLabels(ctx context.Context, name string, la
 
 	ctx = c.AddToken(ctx)
 
-	node, err := c.getNodeByName(ctx, name)
+	node, err := c.getNodeByKey(ctx, key)
 	if err != nil {
 		return observeErr(err)
 	}
@@ -101,7 +103,7 @@ func (c *Client) EnsureUnreservedNodeLabels(ctx context.Context, name string, la
 
 // EnsureComputeOnly ensures that the compute-only behaviour has been applied to
 // the StorageOS node.
-func (c *Client) EnsureComputeOnly(ctx context.Context, name string, enabled bool) error {
+func (c *Client) EnsureComputeOnly(ctx context.Context, key client.ObjectKey, enabled bool) error {
 	funcName := "ensure_compute_only"
 	start := time.Now()
 	defer func() {
@@ -114,7 +116,7 @@ func (c *Client) EnsureComputeOnly(ctx context.Context, name string, enabled boo
 
 	ctx = c.AddToken(ctx)
 
-	node, err := c.getNodeByName(ctx, name)
+	node, err := c.getNodeByKey(ctx, key)
 	if err != nil {
 		return observeErr(err)
 	}

--- a/internal/pkg/storageos/node_labels_test.go
+++ b/internal/pkg/storageos/node_labels_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/storageos/api-manager/internal/pkg/storageos"
 	"github.com/storageos/api-manager/internal/pkg/storageos/mocks"
@@ -249,12 +250,12 @@ func TestClient_EnsureNodeLabels(t *testing.T) {
 
 			c := storageos.NewTestAPIClient(mockCP)
 
-			nodeName := "nodeA"
+			key := client.ObjectKey{Name: "nodeA"}
 			if tt.prepare != nil {
-				tt.prepare(nodeName, mockCP)
+				tt.prepare(key.Name, mockCP)
 			}
 
-			if err := c.EnsureNodeLabels(context.Background(), nodeName, tt.labels); (err != nil) != tt.wantErr {
+			if err := c.EnsureNodeLabels(context.Background(), key, tt.labels); (err != nil) != tt.wantErr {
 				t.Errorf("Client.EnsureNodeLabels() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/pkg/storageos/volume_labels.go
+++ b/internal/pkg/storageos/volume_labels.go
@@ -80,7 +80,7 @@ func (c *Client) EnsureUnreservedVolumeLabels(ctx context.Context, key client.Ob
 
 	ctx = c.AddToken(ctx)
 
-	vol, err := c.getVolumeByKey(ctx, key)
+	vol, err := c.getVolume(ctx, key)
 	if err != nil {
 		return observeErr(err)
 	}
@@ -133,7 +133,7 @@ func (c *Client) EnsureReplicas(ctx context.Context, key client.ObjectKey, desir
 
 	ctx = c.AddToken(ctx)
 
-	vol, err := c.getVolumeByKey(ctx, key)
+	vol, err := c.getVolume(ctx, key)
 	if err != nil {
 		return observeErr(err)
 	}

--- a/internal/pkg/storageos/volume_labels_test.go
+++ b/internal/pkg/storageos/volume_labels_test.go
@@ -16,7 +16,7 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 	tests := []struct {
 		name    string
 		labels  map[string]string
-		prepare func(name string, namespace string, m *mocks.MockControlPlane)
+		prepare func(key client.ObjectKey, m *mocks.MockControlPlane)
 		wantErr bool
 	}{
 		{
@@ -24,17 +24,17 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 			labels: map[string]string{
 				"foo": "bar",
 			},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 				}
 				updateData := api.UpdateVolumeData{
 					Labels: map[string]string{
@@ -50,17 +50,17 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 		{
 			name:   "remove unrestricted label",
 			labels: map[string]string{},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 					Labels: map[string]string{
 						"foo": "bar",
 					},
@@ -79,17 +79,17 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 			labels: map[string]string{
 				storageos.ReservedLabelReplicas: "2",
 			},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 				}
 				replicasData := api.SetReplicasRequest{
 					Replicas: 2,
@@ -97,7 +97,7 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 				volAfterReservedUpdate := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 					Labels: map[string]string{
 						storageos.ReservedLabelReplicas: "2",
 					},
@@ -114,17 +114,17 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 			labels: map[string]string{
 				storageos.ReservedLabelReplicas: "3",
 			},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 					Labels: map[string]string{
 						storageos.ReservedLabelReplicas: "2",
 					},
@@ -135,7 +135,7 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 				volAfterReservedUpdate := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 					Labels: map[string]string{
 						storageos.ReservedLabelReplicas: "3",
 					},
@@ -150,17 +150,17 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 		{
 			name:   "remove existing replicas label",
 			labels: map[string]string{},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 					Labels: map[string]string{
 						storageos.ReservedLabelReplicas: "2",
 					},
@@ -171,7 +171,7 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 				volAfterReservedUpdate := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 					Labels: map[string]string{
 						storageos.ReservedLabelReplicas: "0",
 					},
@@ -188,17 +188,17 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 			labels: map[string]string{
 				storageos.ReservedLabelReplicas: "not-an-integer",
 			},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 				}
 
 				m.EXPECT().ListNamespaces(gomock.Any()).Return([]api.Namespace{ns}, nil, nil).Times(2)
@@ -213,17 +213,17 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 				"boo":                           "baz",
 				storageos.ReservedLabelReplicas: "2",
 			},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 				}
 				replicasData := api.SetReplicasRequest{
 					Replicas: 2,
@@ -231,7 +231,7 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 				volAfterReservedUpdate := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 					Labels: map[string]string{
 						storageos.ReservedLabelReplicas: "2",
 					},
@@ -258,17 +258,17 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 				"boo":                              "baz",
 				storageos.ReservedLabelComputeOnly: "2", // compute-only not allowed on volumes
 			},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 				}
 				updateData := api.UpdateVolumeData{
 					Labels: map[string]string{
@@ -288,17 +288,17 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 			labels: map[string]string{
 				storageos.ReservedLabelComputeOnly: "true",
 			},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 				}
 
 				m.EXPECT().ListNamespaces(gomock.Any()).Return([]api.Namespace{ns}, nil, nil).Times(2)
@@ -311,17 +311,17 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 			labels: map[string]string{
 				storageos.ReservedLabelNoCache: "true",
 			},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 				}
 
 				m.EXPECT().ListNamespaces(gomock.Any()).Return([]api.Namespace{ns}, nil, nil).Times(2)
@@ -334,17 +334,17 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 			labels: map[string]string{
 				storageos.ReservedLabelNoCompress: "true",
 			},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 				}
 
 				m.EXPECT().ListNamespaces(gomock.Any()).Return([]api.Namespace{ns}, nil, nil).Times(2)
@@ -367,7 +367,7 @@ func TestClient_EnsureVolumeLabels(t *testing.T) {
 
 			key := client.ObjectKey{Name: pvcName, Namespace: pvcNamespace}
 			if tt.prepare != nil {
-				tt.prepare(pvcName, pvcNamespace, mockCP)
+				tt.prepare(key, mockCP)
 			}
 
 			if err := c.EnsureVolumeLabels(context.Background(), key, tt.labels); (err != nil) != tt.wantErr {
@@ -381,7 +381,7 @@ func TestClient_EnsureUnreservedVolumeLabels(t *testing.T) {
 	tests := []struct {
 		name    string
 		labels  map[string]string
-		prepare func(name string, namespace string, m *mocks.MockControlPlane)
+		prepare func(key client.ObjectKey, m *mocks.MockControlPlane)
 		wantErr bool
 	}{
 		{
@@ -389,17 +389,17 @@ func TestClient_EnsureUnreservedVolumeLabels(t *testing.T) {
 			labels: map[string]string{
 				"foo": "bar",
 			},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 				}
 				updateData := api.UpdateVolumeData{
 					Labels: map[string]string{
@@ -417,17 +417,17 @@ func TestClient_EnsureUnreservedVolumeLabels(t *testing.T) {
 			labels: map[string]string{
 				"foo": "baz",
 			},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 					Labels: map[string]string{
 						"foo": "bar",
 					},
@@ -446,17 +446,17 @@ func TestClient_EnsureUnreservedVolumeLabels(t *testing.T) {
 		{
 			name:   "remove unrestricted label",
 			labels: map[string]string{},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 					Labels: map[string]string{
 						"foo": "bar",
 					},
@@ -475,17 +475,17 @@ func TestClient_EnsureUnreservedVolumeLabels(t *testing.T) {
 			labels: map[string]string{
 				storageos.ReservedLabelReplicas: "1",
 			},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 				}
 
 				m.EXPECT().ListNamespaces(gomock.Any()).Return([]api.Namespace{ns}, nil, nil).Times(1)
@@ -497,17 +497,17 @@ func TestClient_EnsureUnreservedVolumeLabels(t *testing.T) {
 			labels: map[string]string{
 				storageos.ReservedLabelReplicas: "1",
 			},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 					Labels:      map[string]string{},
 				}
 
@@ -520,17 +520,17 @@ func TestClient_EnsureUnreservedVolumeLabels(t *testing.T) {
 			labels: map[string]string{
 				storageos.ReservedLabelReplicas: "2",
 			},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 					Labels: map[string]string{
 						storageos.ReservedLabelReplicas: "1",
 					},
@@ -543,17 +543,17 @@ func TestClient_EnsureUnreservedVolumeLabels(t *testing.T) {
 		{
 			name:   "remove unrestricted label",
 			labels: map[string]string{},
-			prepare: func(name string, namespace string, m *mocks.MockControlPlane) {
+			prepare: func(key client.ObjectKey, m *mocks.MockControlPlane) {
 				nsId := uuid.New().String()
 				volId := uuid.New().String()
 				ns := api.Namespace{
 					Id:   nsId,
-					Name: namespace,
+					Name: key.Namespace,
 				}
 				vol := api.Volume{
 					Id:          volId,
 					NamespaceID: nsId,
-					Name:        name,
+					Name:        key.Name,
 					Labels: map[string]string{
 						storageos.ReservedLabelReplicas: "1",
 					},
@@ -578,7 +578,7 @@ func TestClient_EnsureUnreservedVolumeLabels(t *testing.T) {
 
 			key := client.ObjectKey{Name: pvcName, Namespace: pvcNamespace}
 			if tt.prepare != nil {
-				tt.prepare(pvcName, pvcNamespace, mockCP)
+				tt.prepare(key, mockCP)
 			}
 			if err := c.EnsureUnreservedVolumeLabels(context.Background(), key, tt.labels); (err != nil) != tt.wantErr {
 				t.Errorf("Client.EnsureUnreservedVolumeLabels() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
No functional changes - this applies the same function signature that was used for Volume API calls to nodes and namespaces, and consolidates some similar functions.

The shared volume `SetExternalEndpoint()` was left as-is as the volume ID is known and used instead as an optimisation.