### PR TITLE
Run shared volume controller with manager

### DIFF
--- a/controllers/namespace_delete_test.go
+++ b/controllers/namespace_delete_test.go
@@ -38,7 +38,7 @@ func SetupNamespaceDeleteTest(ctx context.Context, createK8sNamespace bool, gcEn
 		err := api.AddNamespace(key)
 		Expect(err).NotTo(HaveOccurred(), "failed to create test namespace in storageos")
 
-		mgr, err := ctrl.NewManager(cfg, ctrl.Options{})
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{MetricsBindAddress: "0"})
 		Expect(err).NotTo(HaveOccurred(), "failed to create manager")
 
 		gcInterval := defaultSyncInterval

--- a/controllers/node_delete_test.go
+++ b/controllers/node_delete_test.go
@@ -44,7 +44,7 @@ func SetupNodeDeleteTest(ctx context.Context, createK8sNode bool, isStorageOS bo
 		err := api.AddNode(storageos.MockObject{Name: key.Name})
 		Expect(err).NotTo(HaveOccurred(), "failed to create test node in storageos")
 
-		mgr, err := ctrl.NewManager(cfg, ctrl.Options{})
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{MetricsBindAddress: "0"})
 		Expect(err).NotTo(HaveOccurred(), "failed to create manager")
 
 		gcInterval := defaultSyncInterval

--- a/controllers/node_label_sync_test.go
+++ b/controllers/node_label_sync_test.go
@@ -50,7 +50,7 @@ func SetupNodeLabelSyncTest(ctx context.Context, isStorageOS bool, createLabels 
 		err = api.AddNode(storageos.MockObject{Name: key.Name})
 		Expect(err).NotTo(HaveOccurred(), "failed to create test node in storageos")
 
-		mgr, err := ctrl.NewManager(cfg, ctrl.Options{})
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{MetricsBindAddress: "0"})
 		Expect(err).NotTo(HaveOccurred(), "failed to create manager")
 
 		gcInterval := defaultSyncInterval

--- a/controllers/pvc_label_sync_test.go
+++ b/controllers/pvc_label_sync_test.go
@@ -80,7 +80,7 @@ func SetupPVCLabelSyncTest(ctx context.Context, isStorageOS bool, createLabels m
 		err = api.AddVolume(vol)
 		Expect(err).NotTo(HaveOccurred(), "failed to create test volume in storageos")
 
-		mgr, err := ctrl.NewManager(cfg, ctrl.Options{})
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{MetricsBindAddress: "0"})
 		Expect(err).NotTo(HaveOccurred(), "failed to create manager")
 
 		gcInterval := defaultSyncInterval

--- a/internal/pkg/storageos/client.go
+++ b/internal/pkg/storageos/client.go
@@ -195,7 +195,8 @@ func Authenticate(client *api.APIClient, username, password string) (context.Con
 // Refresh the api token on a given interval, or reset is received on the reset
 // channel.  This function is blocking and is intended to be run in a goroutine.
 // Errors are currently logged at info level since they will be retried and
-// should be recoverable.
+// should be recoverable.  Only a cancelled context will cause this to stop.  Be
+// aware that any errors returned will trigger a process shutdown.
 func (c *Client) Refresh(ctx context.Context, secretPath, endpoint string, reset chan struct{}, interval time.Duration, resultCounter metrics.ResultMetric, log logr.Logger) error {
 	if c.api == nil || c.transport == nil {
 		return ErrNotInitialized


### PR DESCRIPTION
Code simplification to let controller manager handle startup and shutdown of non-k8s controllers like the SharedVolume controller.