### PR TITLE
Add preferred anti affinity to api-manager pods

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,6 +22,18 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: control-plane
+                  operator: In
+                  values:
+                  - controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - command:
         - /manager


### PR DESCRIPTION
Anti affinity will help to avoid scheduling api-manager pods on the same node.
If the node where the API manager pods are scheduled goes offline the pods will enter an unknown state and not be rescheduled for some time. This can delay fencing.