### PR TITLE
Add PVC mutating controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ StorageOS cluster when the namespace has been removed from Kubernetes.
 See [Namespace Delete Controller](controllers/namespace-delete/README.md) for
 more detail.
 
+## Admission Controllers
+
+Admission controllers intercept requests to the Kubernetes API prior to the
+object being persisted, but after authentication and authorisation.
+
+Mutating admission controllers run first and can modify the object, followed by
+Validating admission controllers.  Both can cause the Kubernetes API to reject
+the request.
+
 ### Pod Mutator Admission Controller
 
 The Pod Mutator is a mutating admission controller that modifies Pods during the
@@ -46,6 +55,56 @@ create process.
 
 See [Pod Mutator Admission Controller](controllers/pod-mutator/README.md) for
 more detail.
+
+### PVC Mutator Admission Controller
+
+The PVC Mutator is a mutating admission controller that modifies
+PersistentVolumeClaims during the create process.
+
+See [PVC Mutator Admission Controller](controllers/pvc-mutator/README.md) for
+more detail.
+
+## Webhook Server
+
+The admission controllers run as webhooks within api-manager. The webhook server
+uses a self-signed certificate.
+
+Certificates are rotated automatically and stored in a secret.  Multiple
+instances of the api-manager share the same certificate and will check for
+updates periodically, configured with the `-webhook-cert-refresh-interval` flag.
+
+Certificates are valid for 1 year and re-issued after 6 months.  The
+`-webhook-cert-refresh-interval` should be kept to run frequently (default
+`30m`) as restarting the api-manager will reset the refresh timer.
+
+It is not possible to disable the Webhook server or the admission controllers.
+Instead, disable the individual mutation functions for each admission controller
+so it becomes a no-op.
+
+### Webhook server tunables
+
+`-webhook-cert-refresh-interval` determines how often the webhook server
+certificate should be checked for updates. (default 30m0s).
+
+`-webhook-config-mutating` is the name of the mutating webhook configuration. It
+must match the configuration name set in the cluster-operator. (default
+"storageos-mutating-webhook").
+
+`-webhook-secret-name` Is the name of the webhook secret. (default
+"storageos-webhook").
+
+`-webhook-secret-namespace` Is the namespace of the webhook secret.  If unset
+(recommended), it will be auto-detected and set to the namespace that
+api-manager is installed into.  If auto-detection is not available, it will
+default to the value of `-namespace`, if set.
+
+`-webhook-service-name` is the name of the webhook service. It must match the
+configuration name set in the cluster-operator. (default "storageos-webhook").
+
+`-webhook-service-namespace` is the namespace of the webhook service.  If unset
+(recommended), it will be auto-detected and set to the namespace that
+api-manager is installed into.  If auto-detection is not available, it will
+default to the value of `-namespace`, if set.
 
 ## Initialization
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -25,3 +25,22 @@ webhooks:
     resources:
     - pods
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-pvcs
+  failurePolicy: Ignore
+  name: pvc-mutator.storageos.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - persistentvolumeclaims
+  sideEffects: None

--- a/controllers/pod-mutator/README.md
+++ b/controllers/pod-mutator/README.md
@@ -9,27 +9,8 @@ The Pod Mutator can run multiple mutation functions, each performing a different
 task:
 
 - The Pod Scheduler mutator adds the name of the StorageOS scheduler extender to
-  the Pod's `SchedulerName`.  See [Pod Scheduler
-  Mutator](controllers/pod-mutator/scheduler/README.md) for more detail.
-
-## Webhook server
-
-The admission controller runs as a webhook within api-manager.
-The webhook server uses a self-signed certificate.
-
-Certificates are rotated automatically and stored in a secret.  Multiple
-instances of the api-manager share the same certificate and will check for
-updates periodically, configured with the `-webhook-cert-refresh-interval` flag.
-
-Certificates are valid for 1 year and re-issued after 6 months.  The
-`-webhook-cert-refresh-interval` should be kept to run frequently (default
-`30m`) as restarting the api-manager will reset the refresh timer.
-
-## Disabling
-
-It is not possible to disable the Webhook server.  Instead, disable the
-individual mutation functions so the Pod Mutation becomes a no-op.
-
+  the Pod's `SchedulerName`.  See [Pod Scheduler Mutator](controllers/pod-mutator/scheduler/README.md) for more detail.
+  
 ## Tunables
 
 Default values work well when the api-manager is installed by the
@@ -41,29 +22,6 @@ support.
 set, the scheduler name must match the name of the scheduler extender configured
 in the StorageOS cluster-operator. (default "storageos-scheduler)".
 
-`-webhook-cert-refresh-interval` determines how often the webhook server
-certificate should be checked for updates. (default 30m0s).
-
-`-webhook-config-mutating` is the name of the mutating webhook configuration. It
-must match the configuration name set in the cluster-operator. (default
-"storageos-mutating-webhook").
-
 `-webhook-mutate-pods-path` is the URL path of the Pod mutating webhook. It
 must match the configuration name set in the cluster-operator. (default
 "/mutate-pods").
-
-`-webhook-secret-name` Is the name of the webhook secret. (default
-"storageos-webhook").
-
-`-webhook-secret-namespace` Is the namespace of the webhook secret.  If unset
-(recommended), it will be auto-detected and set to the namespace that
-api-manager is installed into.  If auto-detection is not available, it will
-default to the value of `-namespace`, if set.
-
-`-webhook-service-name` is the name of the webhook service. It must match the
-configuration name set in the cluster-operator. (default "storageos-webhook").
-
-`-webhook-service-namespace` is the namespace of the webhook service.  If unset
-(recommended), it will be auto-detected and set to the namespace that
-api-manager is installed into.  If auto-detection is not available, it will
-default to the value of `-namespace`, if set.

--- a/controllers/pvc-mutator/README.md
+++ b/controllers/pvc-mutator/README.md
@@ -1,0 +1,15 @@
+# PVC Mutator Admission Controller
+
+The PVC Mutator is a mutating admission controller that modifies
+PersistentVolumeClaims during the create process.
+
+## Mutators
+
+The PVC Mutator can run multiple mutation functions, each performing a different
+task:
+
+- TODO(croomes): List of mutators should be added here.
+
+## Tunables
+
+There are currently no tunable flags for the PVC Mutator.

--- a/controllers/pvc-mutator/controller.go
+++ b/controllers/pvc-mutator/controller.go
@@ -1,0 +1,69 @@
+package pvcmutator
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type Controller struct {
+	client.Client
+	mutators []Mutator
+	decoder  *admission.Decoder
+	log      logr.Logger
+}
+
+type Mutator interface {
+	MutatePVC(ctx context.Context, pvc *corev1.PersistentVolumeClaim, namespace string) error
+}
+
+// Check if the Handler interface is implemented.
+var _ admission.Handler = &Controller{}
+
+// +kubebuilder:webhook:path=/mutate-pvcs,mutating=true,failurePolicy=ignore,sideEffects=None,groups="",resources=persistentvolumeclaims,verbs=create,versions=v1,name=pvc-mutator.storageos.com,admissionReviewVersions=v1
+
+// NewController returns a new PVC mutating admission controller.
+func NewController(k8s client.Client, decoder *admission.Decoder, mutators []Mutator) *Controller {
+	return &Controller{
+		mutators: mutators,
+		Client:   k8s,
+		decoder:  decoder,
+		log:      ctrl.Log,
+	}
+}
+
+// Handle handles an admission request and mutates a pvc object in the request.
+func (c *Controller) Handle(ctx context.Context, req admission.Request) admission.Response {
+	pvc := &corev1.PersistentVolumeClaim{}
+
+	err := c.decoder.Decode(req, pvc)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Get the request namespace. This is needed because sometimes the decoded
+	// pvc object lacks namespace info.
+	namespace := req.AdmissionRequest.Namespace
+
+	// Create a copy of the pod to mutate.
+	copy := pvc.DeepCopy()
+	for _, m := range c.mutators {
+		if err := m.MutatePVC(ctx, copy, namespace); err != nil {
+			c.log.Error(err, "failed to mutate pvc")
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
+	}
+
+	marshaledPVC, err := json.Marshal(copy)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPVC)
+}

--- a/controllers/pvc_mutator_test.go
+++ b/controllers/pvc_mutator_test.go
@@ -1,0 +1,207 @@
+package controllers
+
+import (
+	"context"
+	"time"
+
+	"github.com/darkowlzz/operator-toolkit/webhook/cert"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	pvcmutator "github.com/storageos/api-manager/controllers/pvc-mutator"
+)
+
+// SetupPVCMutatorTest will set up a testing environment.  It must be called
+// from each test.
+func SetupPVCMutatorTest(ctx context.Context, mutators []pvcmutator.Mutator) {
+	var cancel func()
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithCancel(ctx)
+
+		// Configure the certificate manager.
+		certOpts := cert.Options{
+			Service: &admissionv1.ServiceReference{
+				Name:      webhookServiceName,
+				Namespace: webhookServiceNamespace,
+			},
+			Client:                    k8sClient,
+			SecretRef:                 &types.NamespacedName{Name: webhookSecretName, Namespace: webhookSecretNamespace},
+			MutatingWebhookConfigRefs: []types.NamespacedName{{Name: webhookMutatingConfigName}},
+		}
+
+		err := cert.NewManager(nil, certOpts)
+		Expect(err).NotTo(HaveOccurred(), "unable to provision certificate")
+
+		webhookInstallOptions := &testEnv.WebhookInstallOptions
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Host:               webhookInstallOptions.LocalServingHost,
+			Port:               webhookInstallOptions.LocalServingPort,
+			CertDir:            webhookInstallOptions.LocalServingCertDir,
+			LeaderElection:     false,
+			MetricsBindAddress: "0",
+		})
+		Expect(err).NotTo(HaveOccurred(), "failed to create manager")
+
+		decoder, err := admission.NewDecoder(mgr.GetScheme())
+		Expect(err).NotTo(HaveOccurred(), "failed to create decoder")
+
+		pvcMutator := pvcmutator.NewController(mgr.GetClient(), decoder, mutators)
+		mgr.GetWebhookServer().Register(webhookMutatePVCsPath, &webhook.Admission{Handler: pvcMutator})
+		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
+
+		go func() {
+			err := mgr.Start(ctx)
+			Expect(err).NotTo(HaveOccurred(), "failed to start manager")
+		}()
+
+		// Wait for manager to be ready.
+		time.Sleep(managerWaitDuration)
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+}
+
+var _ = Describe("PVC Mutator controller", func() {
+	// Define utility constants for object names and testing timeouts/durations
+	// and intervals.
+	const (
+		timeout  = time.Second * 1
+		duration = time.Second * 1
+		interval = time.Millisecond * 250
+	)
+
+	genPVC := func() corev1.PersistentVolumeClaim {
+		volumeMode := v1.PersistentVolumeFilesystem
+		return corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pvc-" + randStringRunes(5),
+				Namespace: "default",
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{v1.PersistentVolumeAccessMode("ReadWriteOnce")},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+				VolumeMode: &volumeMode,
+			},
+		}
+	}
+
+	ctx := context.Background()
+
+	Context("When the PVC Mutator has no mutators", func() {
+		SetupPVCMutatorTest(ctx, nil)
+		It("The pvc should be created", func() {
+			pvc := genPVC()
+
+			By("Creating the PVC")
+			Expect(k8sClient.Create(ctx, &pvc)).Should(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
+			}()
+
+			By("Expecting the PVC to be unchanged")
+			Consistently(func() corev1.PersistentVolumeClaim {
+				got := corev1.PersistentVolumeClaim{}
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &got)
+				if err != nil {
+					return corev1.PersistentVolumeClaim{}
+				}
+				return got
+			}, timeout, interval).Should(Equal(pvc))
+		})
+	})
+
+	Context("When the PVC Mutator has one mutator", func() {
+		SetupPVCMutatorTest(ctx, []pvcmutator.Mutator{testMutator{key: "foo", value: "bar"}})
+		It("The pvc should be created", func() {
+			pvc := genPVC()
+
+			By("Creating the PVC")
+			Expect(k8sClient.Create(ctx, &pvc)).Should(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
+			}()
+
+			By("Expecting the PVC to be changed")
+			Eventually(func() map[string]string {
+				got := corev1.PersistentVolumeClaim{}
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &got)
+				if err != nil {
+					return nil
+				}
+				return got.GetAnnotations()
+			}, timeout, interval).Should(Equal(map[string]string{
+				"foo": "bar",
+			}))
+		})
+	})
+
+	Context("When the PVC Mutator has two mutators", func() {
+		SetupPVCMutatorTest(ctx, []pvcmutator.Mutator{
+			testMutator{key: "foo", value: "bar"},
+			testMutator{key: "baz", value: "zab"},
+		})
+		It("The pvc should be created", func() {
+			pvc := genPVC()
+
+			By("Creating the PVC")
+			Expect(k8sClient.Create(ctx, &pvc)).Should(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
+			}()
+
+			By("Expecting the PVC to be changed")
+			Eventually(func() map[string]string {
+				got := corev1.PersistentVolumeClaim{}
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &got)
+				if err != nil {
+					return nil
+				}
+				return got.GetAnnotations()
+			}, timeout, interval).Should(Equal(map[string]string{
+				"foo": "bar",
+				"baz": "zab",
+			}))
+		})
+	})
+
+	Context("When the PVC Mutator has one mutator that errors", func() {
+		SetupPVCMutatorTest(ctx, []pvcmutator.Mutator{testMutator{error: true}})
+		It("The pvc should not be created", func() {
+			pvc := genPVC()
+
+			By("Creating the PVC")
+			Expect(k8sClient.Create(ctx, &pvc)).ShouldNot(Succeed())
+		})
+	})
+
+	Context("When the PVC Mutator has two mutators and one errors", func() {
+		SetupPVCMutatorTest(ctx, []pvcmutator.Mutator{
+			testMutator{key: "foo", value: "bar"},
+			testMutator{error: true}},
+		)
+		It("The pvc should not be created", func() {
+			pvc := genPVC()
+
+			By("Creating the PVC")
+			Expect(k8sClient.Create(ctx, &pvc)).ShouldNot(Succeed())
+		})
+	})
+
+})

--- a/controllers/test_helpers.go
+++ b/controllers/test_helpers.go
@@ -14,6 +14,7 @@ const (
 	webhookSecretName         = "storageos-webhook-secret"
 	webhookSecretNamespace    = "kube-system"
 	webhookMutatePodsPath     = "/mutate-pods"
+	webhookMutatePVCsPath     = "/mutate-pvcs"
 )
 
 // testMutator is a test mutator that adds an annotation to pods or pvcs.


### PR DESCRIPTION
Adds the controller to handle mutating PVC create requests.  There will be a separate operator PR to create the MutatingWebhookConfiguration, but this can come later.

No mutators have been added at this point.

I'll re-target to master after https://github.com/storageos/api-manager/pull/41 merges.