### PR TITLE
Migrate to kubebuilder v3

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
+# Ignore all files which are not go type
+!**/*.go
+!**/*.mod
+!**/*.sum

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run go test
         run: make test
       - name: Run go build
-        run: make manager
+        run: make build
 
   build-image:
     name: Build container image

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.so
 *.dylib
 bin
+testbin/*
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,15 @@
 # Image URL to use all building/pushing image targets
 IMG ?= storageos/api-manager:test
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
-OS=$(shell go env GOOS)
-ARCH=$(shell go env GOARCH)
-KUBEBUILDER_VERSION=2.3.1
-DEFAULT_KUBEBUILDER_PATH=/usr/local/kubebuilder/bin
+KUBEBUILDER_VERSION=3.0.0-rc.0
+CONTROLLER_RUNTIME_VERSION=0.8.3
+CONTROLLER_TOOLS_VERSION=0.4.1
+KUSTOMIZE_VERSION=3.8.7
+# Set the shell as a workaround for the issue
+# https://github.com/operator-framework/operator-sdk/issues/4203
+SHELL=bash
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -16,86 +19,114 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-all: manager
+all: build
 
-# Install kubebuilder tools. This is required for running envtest.
-kubebuilder:
-	@if [ ! -d $(DEFAULT_KUBEBUILDER_PATH) ]; then \
-		curl -L https://go.kubebuilder.io/dl/$(KUBEBUILDER_VERSION)/$(OS)/$(ARCH) | tar -xz -C /tmp/; \
-		sudo mv /tmp/kubebuilder_$(KUBEBUILDER_VERSION)_$(OS)_$(ARCH)/ /usr/local/kubebuilder; \
-	fi
+##@ General
 
-# Run tests
-test: kubebuilder generate fmt vet manifests
-	go test -mod=vendor -timeout 300s ./... -coverprofile cover.out
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
 
-# Build manager binary
-manager: generate fmt vet tidy
-	go build -mod=vendor -o bin/manager main.go
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-# Prune, add and vendor go dependencies.
-tidy:
-	go mod tidy -v
-	go mod vendor -v
+##@ Development
 
-# Run against the configured Kubernetes cluster in ~/.kube/config
-run: generate fmt vet manifests secret
-	go run -mod=vendor ./main.go -api-secret-path=$(PWD)/.secret
-
-# Install CRDs into a cluster
-install: manifests
-	kustomize build config/crd | kubectl apply -f -
-
-# Uninstall CRDs from a cluster
-uninstall: manifests
-	kustomize build config/crd | kubectl delete -f -
-
-# Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-deploy: manifests
-	cd config/manager && kustomize edit set image controller=${IMG}
-	kustomize build config/default | kubectl apply -f -
-
-# Generate manifests e.g. CRD, RBAC etc.
-manifests: controller-gen
+manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
-# Run go fmt against code
-fmt:
-	go fmt ./...
-
-# Run go vet against code
-vet:
-	go vet ./...
-
-# Generate code
-generate: controller-gen mockgen
+generate: controller-gen mockgen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 	go generate ./...
 
-# Build the docker image
-docker-build:
+fmt: ## Run go fmt against code.
+	go fmt ./...
+
+vet: ## Run go vet against code.
+	go vet ./...
+
+ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
+test: kubebuilder generate fmt vet manifests ## Run tests.
+	mkdir -p ${ENVTEST_ASSETS_DIR}
+	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v$(CONTROLLER_RUNTIME_VERSION)/hack/setup-envtest.sh
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -mod=vendor -timeout 300s ./... -coverprofile cover.out
+
+##@ Build
+
+build: generate fmt vet tidy ## Build manager binary.
+	go build -mod=vendor -o bin/manager main.go
+
+tidy: ## Prune, add and vendor go dependencies.
+	go mod tidy -v
+	go mod vendor -v
+
+run: generate fmt vet manifests secret ## Run a controller from your host.
+	go run -mod=vendor ./main.go -api-secret-path=$(PWD)/.secret
+
+docker-build: ## Build the docker image with the manager.
 	docker build . -t ${IMG}
 
-# Push the docker image
-docker-push:
+docker-push: ## Push the docker image with the manager.
 	docker push ${IMG}
 
-# find or download controller-gen
-# download controller-gen if necessary
-controller-gen:
-ifeq (, $(shell which controller-gen))
-	@{ \
+##@ Deployment
+
+install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
+	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+
+uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
+	$(KUSTOMIZE) build config/crd | kubectl delete -f -
+
+deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	cd config/manager && kustomize edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default | kubectl apply -f -
+
+undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
+	$(KUSTOMIZE) build config/default | kubectl delete -f -
+
+
+KUBEBUILDER = $(shell pwd)/bin/kubebuilder
+kubebuilder: ## Download kubebuilder locally if necessary.
+	@[ -f $(KUBEBUILDER) ] || { \
 	set -e ;\
-	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$CONTROLLER_GEN_TMP_DIR ;\
+	TMP_DIR=$$(mktemp -d) ;\
+	cd $$TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
-	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
+	GOBIN=$(PROJECT_DIR)/bin go get sigs.k8s.io/kubebuilder/v3/cmd@v$(KUBEBUILDER_VERSION) ;\
+	rm -rf $$TMP_DIR ;\
+	cd - && mv bin/cmd $(KUBEBUILDER) ;\
 	}
-CONTROLLER_GEN=$(GOBIN)/controller-gen
-else
-CONTROLLER_GEN=$(shell which controller-gen)
-endif
+
+CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
+controller-gen: ## Download controller-gen locally if necessary.
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v$(CONTROLLER_TOOLS_VERSION))
+
+KUSTOMIZE = $(shell pwd)/bin/kustomize
+kustomize: ## Download kustomize locally if necessary.
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v$(KUSTOMIZE_VERSION))
+
+
+# go-get-tool will 'go get' any package $2 and install it to $1.
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+define go-get-tool
+@[ -f $(1) ] || { \
+set -e ;\
+TMP_DIR=$$(mktemp -d) ;\
+cd $$TMP_DIR ;\
+go mod init tmp ;\
+echo "Downloading $(2)" ;\
+GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+rm -rf $$TMP_DIR ;\
+}
+endef
+
 
 # Install mockgen
 mockgen:

--- a/PROJECT
+++ b/PROJECT
@@ -1,4 +1,7 @@
 domain: storageos.com
+layout:
+- go.kubebuilder.io/v3
+projectName: api-manager
 repo: github.com/storageos/api-manager
 resources:
-version: "2"
+version: "3"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
-  newTag: latest
+  newName: storageos/api-manager
+  newTag: test

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -6,8 +6,9 @@ metadata:
   creationTimestamp: null
   name: mutating-webhook-configuration
 webhooks:
-- clientConfig:
-    caBundle: Cg==
+- admissionReviewVersions:
+  - v1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -23,3 +24,4 @@ webhooks:
     - CREATE
     resources:
     - pods
+  sideEffects: None

--- a/controllers/admission/scheduler/handler.go
+++ b/controllers/admission/scheduler/handler.go
@@ -44,7 +44,7 @@ type PodSchedulerSetter struct {
 // Check if the Handler interface is implemented.
 var _ admission.Handler = &PodSchedulerSetter{}
 
-// +kubebuilder:webhook:path=/mutate-pods,mutating=true,failurePolicy=ignore,groups="",resources=pods,verbs=create,versions=v1,name=pod-mutator.storageos.com
+// +kubebuilder:webhook:path=/mutate-pods,mutating=true,failurePolicy=ignore,sideEffects=None,groups="",resources=pods,verbs=create,versions=v1,name=pod-mutator.storageos.com,admissionReviewVersions=v1
 
 // NewPodSchedulerSetter returns a new Pod Scheduler mutating admission
 // controller.


### PR DESCRIPTION
- Updates the makefile to be based on the kubebuilder v3 makefile.
- Update kubebuilder, controller-tools and kustomize dependencies. All
the binaries are downloaded into ./bin dir. And all the test related
binaries are downloaded in testbin. Old assets in
/usr/local/kubebuilder/ can be deleted. All the dependencies are
maintained within the project directory.
- envtest related tools are downloaded when the tests are run. All build
and test dependencies are self-contained now.
- Update all the generated code and configs.
- make help shows a list of all the targets with description.

NOTE: We have already been using most of the kubebuilder v3 dependencies
with the latest stable controller-runtime. This change moves the project scaffold,
code generation and testing tools to the versions used in kubebuilder v3.
Although kubebuilder v3 doesn't officially supports go 1.16 yet, since we don't
have any custom resources API generation in this project, we are good to use
go 1.16.