### PR TITLE
Add defaults from StorageClass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: kubebuilder generate fmt vet manifests ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v$(CONTROLLER_RUNTIME_VERSION)/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -mod=vendor -timeout 300s ./... -coverprofile cover.out
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -mod=vendor -timeout 600s ./... -coverprofile cover.out
 
 ##@ Build
 

--- a/controllers/pvc-label/README.md
+++ b/controllers/pvc-label/README.md
@@ -4,20 +4,45 @@ The PVC Label Sync Controller is responsible for syncing labels set on
 Kubernetes PVCs to the StorageOS volume objects.
 
 Labels are initially set at creation time by a custom [CSI Provisioner], that
-adds PVC labels to the CSI CreateVolume parameters.
+adds PVC labels to the CSI CreateVolume parameters.  These are added on top of
+any default parameters set in the StorageClass parameters.
 
 This controller ensures that any PVC label changes are applied.
 
 Some StorageOS functionality, such as setting the number of desired replicas, is
-done by setting the `storageos.com/replicas=N` label on a Kubernetes PVC (where
-N is from 0-6).  This controller ensures that the behaviour is applied to the
-StorageOS volume.
+done by setting or changing the `storageos.com/replicas=N` label on a Kubernetes
+PVC (where N is from 0-6).  This controller ensures that the behaviour is
+applied to the StorageOS volume after it has been created.
 
 Other labels, such as `storageos.com/nocache` and `storageos.com/nocompress` can
 only be set when the volume is created, so the PVC Label Sync Controller ignores
 them.
 
 See [StorageOS Feature Labels] for more information.
+
+# StorageClass Defaults
+
+Cluster administrators may set defaults for volumes by setting feature labels as
+parameters in the StorageClass.  The PVC Label Sync Controller will load the
+StorageClass parameters prior to applying any label changes to ensure that they
+are taken into account and not removed.
+
+The controller needs to ensure that the defaults set in the StorageClass have
+not changed since the volume was provisioned.  Otherwise a change to a feature
+label in the StorageClass would get immediately applied to all volumes, which
+would not be the expected behaviour.
+
+Since StorageClasses are immutable, to change a parameter requires deleting and
+recreating the StorageClass.  To detect this, when the PVC is created, the UID
+of the StorageClass is set in the `storageos.com/storageclass` annotation on the
+PVC by the [PVC StorageClass Annotation
+Mutator](controllers/pvc-mutator/storageclass/README.md).  The PVC Label Sync
+Controller verifies that the current StorageClass UID matches.  If not, labels
+are not synchronised for the PVC.
+
+To re-enable PVC label sync when there is a StorageClass UID mismatch, manually confirm
+that any StorageClass parameter changes are intended to be applied, then remove
+the PVC StorageClass annotation.
 
 ## Trigger
 

--- a/controllers/pvc-label/reconciler.go
+++ b/controllers/pvc-label/reconciler.go
@@ -53,7 +53,7 @@ func NewReconciler(api VolumeLabeller, k8s client.Client, resyncDelay time.Durat
 
 // SetupWithManager registers the controller with the controller manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, workers int) error {
-	c, err := NewController(r.api, mgr.GetScheme(), r.log)
+	c, err := NewController(r.Client, r.api, mgr.GetScheme(), r.log)
 	if err != nil {
 		return err
 	}

--- a/controllers/pvc-mutator/README.md
+++ b/controllers/pvc-mutator/README.md
@@ -12,6 +12,9 @@ task:
   ensures that PVCs that have requested encryption have a valid configuration,
   generating encryption keys if needed.
 
+- [StorageClass to annotation](/controllers/pvc-mutator/storageclass/README.md):
+  ensures that StorageOS related PVCs have their StorageClass' UID as an annotation.
+
 ## Tunables
 
 There are currently no tunable flags for the PVC Mutator.

--- a/controllers/pvc-mutator/storageclass/README.md
+++ b/controllers/pvc-mutator/storageclass/README.md
@@ -1,0 +1,23 @@
+# PVC StorageClass Annotation Mutator
+
+The PVC StorageClass Annotation Mutator tries to detect the StorageClass of the
+PVC being created and sets the StorageClass' UID in the
+`storageos.com/storageclass` annotation on the PVC.
+This allows StorageOS to detect whether the StorageClass parameters used to
+create the volume may have been changed later.  Since StorageClasses are
+immutable, deleting and recreating the StorageClass is the only way to change
+parameters.
+
+## Trigger
+
+Only PVCs that will be provisioned by StorageOS are candidates for mutation.
+
+## Failure Policy
+
+Failure to set the StorageClass annotation should not cause the PVC creation to
+fail.
+
+## Tunables
+
+There are currently no tunable flags for the PVC StorageClass Annotation
+Mutator.

--- a/controllers/pvc-mutator/storageclass/annotation.go
+++ b/controllers/pvc-mutator/storageclass/annotation.go
@@ -1,0 +1,59 @@
+package storageclass
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"github.com/storageos/api-manager/internal/pkg/provisioner"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AnnotationSetter is responsible to add an annotation
+// to link the StorageClass with the PVC.
+type AnnotationSetter struct {
+	client.Client
+	log logr.Logger
+}
+
+// NewAnnotationSetter returns a new PVC annotation mutating admission
+// controller.
+func NewAnnotationSetter(k8s client.Client) *AnnotationSetter {
+	return &AnnotationSetter{
+		Client: k8s,
+		log:    ctrl.Log.WithName("storageclass"),
+	}
+}
+
+// MutatePVC mutates a given pvc with a new annotation,
+// by attached StorageClass.
+//
+// Errors returned here may block creation of the PVC, depending on the
+// FailurePolicy set in the webhook configuration.
+func (s *AnnotationSetter) MutatePVC(ctx context.Context, pvc *corev1.PersistentVolumeClaim, namespace string) error {
+	log := s.log.WithValues("pvc", client.ObjectKeyFromObject(pvc).String())
+	log.V(4).Info("received pvc for mutation")
+
+	// Find StorageClass of PVC.
+	storageClass, err := provisioner.StorageClassForPVC(s.Client, pvc)
+	if err != nil {
+		return errors.Wrap(err, "failed to check pvc provisioner")
+	}
+
+	// Skip mutation if the PVC will not be provisioned by StorageOS.
+	if provisioned := provisioner.IsProvisionedStorageClass(storageClass, provisioner.DriverName); !provisioned {
+		log.V(4).Info("pvc will not be provisioned by StorageOS, skipping")
+		return nil
+	}
+
+	// Set annotation on the PVC based on StorageClass.
+	if pvc.Annotations == nil {
+		pvc.Annotations = make(map[string]string)
+	}
+	pvc.Annotations[provisioner.StorageClassUUIDAnnotationKey] = string(storageClass.UID)
+
+	log.Info("set StorageClass UID as annotation", "pvc", pvc.Name, "uid", string(storageClass.UID))
+	return nil
+}

--- a/controllers/pvc-mutator/storageclass/annotation_test.go
+++ b/controllers/pvc-mutator/storageclass/annotation_test.go
@@ -1,0 +1,212 @@
+package storageclass
+
+import (
+	"context"
+	"testing"
+
+	"github.com/storageos/api-manager/internal/pkg/provisioner"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestMutatePVCErrorToFetchStorageClass(t *testing.T) {
+	// Create a new scheme and add all the types from different clientsets.
+	scheme := runtime.NewScheme()
+	if err := kscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a fake client to fail on get StorageClass.
+	k8s := fake.NewClientBuilder().Build()
+
+	// Create a AnnotationSetter instance with the fake client.
+	annotationSetter := AnnotationSetter{
+		Client: k8s,
+		log:    ctrl.Log,
+	}
+
+	namespace := "namespace"
+
+	// Create a pvc.
+	pvc := createPVC("pvc1", namespace, nil)
+
+	err := annotationSetter.MutatePVC(context.Background(), pvc, namespace)
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+}
+
+func TestMutatePVC(t *testing.T) {
+	// Create a new scheme and add all the types from different clientsets.
+	scheme := runtime.NewScheme()
+	if err := kscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	// Default StorageOS StorageClass.
+	defStosSC := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  types.UID("storageos-default-uid"),
+			Name: "stos-default",
+			Annotations: map[string]string{
+				provisioner.DefaultStorageClassKey: "true",
+			},
+		},
+		Provisioner: provisioner.DriverName,
+	}
+
+	// StorageOS StorageClass.
+	stosSC := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  types.UID("storageos-uid"),
+			Name: "stos",
+		},
+		Provisioner: provisioner.DriverName,
+	}
+
+	// Default non-StorageOS StorageClass.
+	defaultNotStosSC := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  types.UID("default-foo-uid"),
+			Name: "default-non-stos",
+			Annotations: map[string]string{
+				provisioner.DefaultStorageClassKey: "true",
+			},
+		},
+		Provisioner: "foo-provisioner",
+	}
+
+	// Non-StorageOS StorageClass.
+	notStosSC := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  types.UID("foo-uid"),
+			Name: "non-stos",
+		},
+		Provisioner: "foo-provisioner",
+	}
+
+	testNamespace := "default"
+
+	testcases := []struct {
+		name                string
+		namespace           string
+		storageClass        *storagev1.StorageClass
+		defaultStorageClass *storagev1.StorageClass
+	}{
+		{
+			name:                "not given with foreign default",
+			namespace:           testNamespace,
+			storageClass:        nil,
+			defaultStorageClass: defaultNotStosSC,
+		},
+		{
+			name:                "not given with StorageOS default",
+			namespace:           testNamespace,
+			storageClass:        nil,
+			defaultStorageClass: defStosSC,
+		},
+		{
+			name:                "foreign given with foreign default",
+			namespace:           testNamespace,
+			storageClass:        notStosSC,
+			defaultStorageClass: defaultNotStosSC,
+		},
+		{
+			name:                "foreign given with StorageOS default",
+			namespace:           testNamespace,
+			storageClass:        notStosSC,
+			defaultStorageClass: defStosSC,
+		},
+		{
+			name:                "StorageOS given with foreign default",
+			namespace:           testNamespace,
+			storageClass:        stosSC,
+			defaultStorageClass: defaultNotStosSC,
+		},
+		{
+			name:                "StorageOS given with StorageOS default",
+			namespace:           testNamespace,
+			storageClass:        stosSC,
+			defaultStorageClass: defStosSC,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Create all the above resources and get a k8s client.
+			k8sBuilder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.defaultStorageClass)
+			if tc.storageClass != nil {
+				k8sBuilder.WithObjects(tc.storageClass)
+			}
+
+			// Create a AnnotationSetter instance with the fake client.
+			annotationSetter := AnnotationSetter{
+				Client: k8sBuilder.Build(),
+				log:    ctrl.Log,
+			}
+
+			// Create a pvc.
+			pvc := createPVC("pvc1", tc.namespace, tc.storageClass)
+
+			err := annotationSetter.MutatePVC(context.Background(), pvc, tc.namespace)
+			if err != nil {
+				t.Fatalf("got unexpected error: %v", err)
+			}
+
+			// Collect annotation to test.
+			scAnnotation, ok := pvc.Annotations[provisioner.StorageClassUUIDAnnotationKey]
+
+			// Select default if not given.
+			storageClass := tc.defaultStorageClass
+			if tc.storageClass != nil {
+				storageClass = tc.storageClass
+			}
+
+			// Validate result.
+			switch storageClass.Provisioner {
+			case provisioner.DriverName:
+				if scAnnotation != string(storageClass.UID) {
+					t.Errorf("annotation value got:\n%s\n, want:\n%s", scAnnotation, string(storageClass.UID))
+				}
+			default:
+				if ok {
+					t.Error("annotation found for foreign")
+				}
+			}
+		})
+	}
+}
+
+// createPVC creates and returns a PVC object.
+func createPVC(name, namespace string, storageClass *storagev1.StorageClass) *corev1.PersistentVolumeClaim {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	if storageClass != nil {
+		pvc.Spec.StorageClassName = &storageClass.Name
+	}
+
+	return pvc
+}

--- a/controllers/pvc_keygen_test.go
+++ b/controllers/pvc_keygen_test.go
@@ -10,7 +10,6 @@ import (
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -39,7 +38,7 @@ func SetupPVCKeygenTest(ctx context.Context, addMutator bool, isStorageOS bool) 
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",
 			Annotations: map[string]string{
-				defaultStorageClassKey: "true",
+				provisioner.DefaultStorageClassKey: "true",
 			},
 		},
 		Provisioner: driver,
@@ -118,24 +117,14 @@ var _ = Describe("PVC Keygen controller", func() {
 	)
 
 	genPVC := func(labels map[string]string, annotations map[string]string) corev1.PersistentVolumeClaim {
-		volumeMode := corev1.PersistentVolumeFilesystem
-		return corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        "pvc-" + randStringRunes(5),
-				Namespace:   "default",
-				Labels:      labels,
-				Annotations: annotations,
-			},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.PersistentVolumeAccessMode("ReadWriteOnce")},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("1Gi"),
-					},
-				},
-				VolumeMode: &volumeMode,
-			},
-		}
+		pvc := genPVC()
+
+		pvc.Labels = labels
+		pvc.Annotations = annotations
+		vm := corev1.PersistentVolumeFilesystem
+		pvc.Spec.VolumeMode = &vm
+
+		return pvc
 	}
 
 	ctx := context.Background()

--- a/controllers/pvc_label_sync_test.go
+++ b/controllers/pvc_label_sync_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -21,7 +22,7 @@ import (
 
 // SetupPVCLabelSyncTest will set up a testing environment.  It must be called
 // from each test.
-func SetupPVCLabelSyncTest(ctx context.Context, isStorageOS bool, createLabels map[string]string, gcEnabled bool) client.ObjectKey {
+func SetupPVCLabelSyncTest(ctx context.Context, sc storagev1.StorageClass, scName string, isStorageOS bool, addSCAnnotation bool, createLabels map[string]string, gcEnabled bool) client.ObjectKey {
 	var ns *corev1.Namespace
 	var pvc *corev1.PersistentVolumeClaim
 	var cancel func()
@@ -43,13 +44,17 @@ func SetupPVCLabelSyncTest(ctx context.Context, isStorageOS bool, createLabels m
 		err := k8sClient.Create(ctx, ns)
 		Expect(err).NotTo(HaveOccurred(), "failed to create test namespace")
 
+		err = k8sClient.Create(ctx, &sc)
+		Expect(err).NotTo(HaveOccurred(), "failed to create test storageclass")
+
 		pvName := "pvc-" + randStringRunes(5)
 		volumeMode := v1.PersistentVolumeFilesystem
 		pvc = &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      key.Name,
-				Namespace: key.Namespace,
-				Labels:    createLabels,
+				Name:        key.Name,
+				Namespace:   key.Namespace,
+				Labels:      createLabels,
+				Annotations: make(map[string]string),
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				AccessModes: []corev1.PersistentVolumeAccessMode{v1.PersistentVolumeAccessMode("ReadWriteOnce")},
@@ -62,10 +67,14 @@ func SetupPVCLabelSyncTest(ctx context.Context, isStorageOS bool, createLabels m
 				VolumeName: pvName,
 			},
 		}
+		if scName != "" {
+			pvc.Spec.StorageClassName = &scName
+		}
 		if isStorageOS {
-			pvc.Annotations = map[string]string{
-				provisioner.PVCProvisionerAnnotationKey: provisioner.DriverName,
-			}
+			pvc.Annotations[provisioner.PVCProvisionerAnnotationKey] = provisioner.DriverName
+		}
+		if addSCAnnotation {
+			pvc.Annotations[provisioner.StorageClassUUIDAnnotationKey] = string(sc.UID)
 		}
 
 		err = k8sClient.Create(ctx, pvc)
@@ -106,6 +115,8 @@ func SetupPVCLabelSyncTest(ctx context.Context, isStorageOS bool, createLabels m
 		Expect(err).NotTo(HaveOccurred(), "failed to delete test pvc")
 		err = k8sClient.Delete(ctx, ns)
 		Expect(err).NotTo(HaveOccurred(), "failed to delete test namespace")
+		err = k8sClient.Delete(ctx, &sc)
+		Expect(err).NotTo(HaveOccurred(), "failed to delete test storageclass")
 		cancel()
 	})
 
@@ -134,10 +145,38 @@ var _ = Describe("PVC Label controller", func() {
 		storageos.ReservedLabelReplicas: "1",
 	}
 
+	genSC := func(isStorageOS bool, params map[string]string) storagev1.StorageClass {
+		sc := storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "sc-" + randStringRunes(5),
+			},
+			Provisioner: provisioner.DriverName,
+			Parameters: map[string]string{
+				"csi.storage.k8s.io/controller-expand-secret-name":       "csi-controller-expand-secret",
+				"csi.storage.k8s.io/controller-expand-secret-namespace":  "kube-system",
+				"csi.storage.k8s.io/controller-publish-secret-name":      "csi-controller-publish-secret",
+				"csi.storage.k8s.io/controller-publish-secret-namespace": "kube-system",
+				"csi.storage.k8s.io/fstype":                              "ext4",
+				"csi.storage.k8s.io/node-publish-secret-name":            "csi-node-publish-secret",
+				"csi.storage.k8s.io/node-publish-secret-namespace":       "kube-system",
+				"csi.storage.k8s.io/provisioner-secret-name":             "csi-provisioner-secret",
+				"csi.storage.k8s.io/provisioner-secret-namespace":        "kube-system",
+			},
+		}
+		if isStorageOS {
+			sc.Provisioner = provisioner.DriverName
+		}
+		for k, v := range params {
+			sc.Parameters[k] = v
+		}
+		return sc
+	}
+
 	ctx := context.Background()
 
 	Context("When adding unreserved labels", func() {
-		key := SetupPVCLabelSyncTest(ctx, true, nil, false)
+		sc := genSC(true, nil)
+		key := SetupPVCLabelSyncTest(ctx, sc, sc.Name, true, true, nil, false)
 		It("Should sync labels to StorageOS Volume", func() {
 			By("Confirming PVC exists in k8s")
 			var pvc corev1.PersistentVolumeClaim
@@ -162,7 +201,8 @@ var _ = Describe("PVC Label controller", func() {
 	})
 
 	Context("When adding reserved labels", func() {
-		key := SetupPVCLabelSyncTest(ctx, true, nil, false)
+		sc := genSC(true, nil)
+		key := SetupPVCLabelSyncTest(ctx, sc, sc.Name, true, true, nil, false)
 		It("Should sync labels to StorageOS Volume", func() {
 			By("Confirming PVC exists in k8s")
 			var pvc corev1.PersistentVolumeClaim
@@ -186,7 +226,8 @@ var _ = Describe("PVC Label controller", func() {
 	})
 
 	Context("When adding mixed labels", func() {
-		key := SetupPVCLabelSyncTest(ctx, true, nil, false)
+		sc := genSC(true, nil)
+		key := SetupPVCLabelSyncTest(ctx, sc, sc.Name, true, true, nil, false)
 		It("Should sync labels to StorageOS Volume", func() {
 			By("Confirming PVC exists in k8s")
 			var pvc corev1.PersistentVolumeClaim
@@ -210,7 +251,8 @@ var _ = Describe("PVC Label controller", func() {
 	})
 
 	Context("When adding unrecognised reserved labels", func() {
-		key := SetupPVCLabelSyncTest(ctx, true, nil, false)
+		sc := genSC(true, nil)
+		key := SetupPVCLabelSyncTest(ctx, sc, sc.Name, true, true, nil, false)
 		It("Should only sync recognised labels to StorageOS Volume", func() {
 			By("Confirming PVC exists in k8s")
 			var pvc corev1.PersistentVolumeClaim
@@ -239,7 +281,8 @@ var _ = Describe("PVC Label controller", func() {
 	})
 
 	Context("When adding replicas label", func() {
-		key := SetupPVCLabelSyncTest(ctx, true, nil, false)
+		sc := genSC(true, nil)
+		key := SetupPVCLabelSyncTest(ctx, sc, sc.Name, true, true, nil, false)
 		It("Should sync labels to StorageOS Volume", func() {
 			By("Confirming PVC exists in k8s")
 			var pvc corev1.PersistentVolumeClaim
@@ -266,7 +309,8 @@ var _ = Describe("PVC Label controller", func() {
 	})
 
 	Context("When adding failure-mode label", func() {
-		key := SetupPVCLabelSyncTest(ctx, true, nil, false)
+		sc := genSC(true, nil)
+		key := SetupPVCLabelSyncTest(ctx, sc, sc.Name, true, true, nil, false)
 		It("Should sync labels to StorageOS Volume", func() {
 			By("Confirming PVC exists in k8s")
 			var pvc corev1.PersistentVolumeClaim
@@ -293,7 +337,8 @@ var _ = Describe("PVC Label controller", func() {
 	})
 
 	Context("When adding and removing mixed labels", func() {
-		key := SetupPVCLabelSyncTest(ctx, true, nil, false)
+		sc := genSC(true, nil)
+		key := SetupPVCLabelSyncTest(ctx, sc, sc.Name, true, true, nil, false)
 		It("Should sync labels to StorageOS Volume", func() {
 			By("Confirming PVC exists in k8s")
 			var pvc corev1.PersistentVolumeClaim
@@ -315,6 +360,7 @@ var _ = Describe("PVC Label controller", func() {
 			}, timeout, interval).Should(Equal(mixedLabels))
 
 			By("By removing labels from k8s PVC")
+			Expect(k8sClient.Get(ctx, key, &pvc)).Should(Succeed())
 			pvc.SetLabels(map[string]string{})
 			Eventually(func() error {
 				return k8sClient.Update(ctx, &pvc)
@@ -332,7 +378,8 @@ var _ = Describe("PVC Label controller", func() {
 	})
 
 	Context("When adding replicas label and the StorageOS API returns an error", func() {
-		key := SetupPVCLabelSyncTest(ctx, true, nil, false)
+		sc := genSC(true, nil)
+		key := SetupPVCLabelSyncTest(ctx, sc, sc.Name, true, true, nil, false)
 		It("Should not sync labels to StorageOS Volume", func() {
 			By("Confirming PVC exists in k8s")
 			var pvc corev1.PersistentVolumeClaim
@@ -362,7 +409,8 @@ var _ = Describe("PVC Label controller", func() {
 	})
 
 	Context("When adding labels on a k8s PVC not provisioned by StorageOS", func() {
-		key := SetupPVCLabelSyncTest(ctx, false, nil, false)
+		sc := genSC(true, nil)
+		key := SetupPVCLabelSyncTest(ctx, sc, sc.Name, false, false, nil, false)
 		It("Should not sync labels to StorageOS Volume", func() {
 			By("Confirming PVC exists in k8s")
 			var pvc corev1.PersistentVolumeClaim
@@ -386,11 +434,111 @@ var _ = Describe("PVC Label controller", func() {
 	})
 
 	Context("When starting after a k8s PVC with labels has been created", func() {
-		key := SetupPVCLabelSyncTest(ctx, true, mixedLabels, true)
+		sc := genSC(true, nil)
+		key := SetupPVCLabelSyncTest(ctx, sc, sc.Name, true, true, mixedLabels, true)
 		It("The resync should update the StorageOS Volume", func() {
 			By("Confirming PVC exists in k8s")
 			var pvc corev1.PersistentVolumeClaim
 			Expect(k8sClient.Get(ctx, key, &pvc)).Should(Succeed())
+
+			By("Expecting StorageOS Volume labels to match")
+			Eventually(func() map[string]string {
+				vol, err := api.GetVolume(ctx, client.ObjectKey{Name: pvc.Spec.VolumeName, Namespace: pvc.GetNamespace()})
+				if err != nil {
+					return nil
+				}
+				return vol.GetLabels()
+			}, timeout, interval).Should(Equal(mixedLabels))
+		})
+	})
+
+	Context("When adding mixed labels and the storageclass has defaults", func() {
+		sc := genSC(true, map[string]string{
+			"foo":                             "default",
+			storageos.ReservedLabelReplicas:   "2",
+			storageos.ReservedLabelNoCompress: "true",
+			storageos.ReservedLabelEncryption: "true",
+		})
+
+		key := SetupPVCLabelSyncTest(ctx, sc, sc.Name, true, true, nil, false)
+		It("Should sync labels to StorageOS Volume", func() {
+			By("Confirming PVC exists in k8s")
+			var pvc corev1.PersistentVolumeClaim
+			Expect(k8sClient.Get(ctx, key, &pvc)).Should(Succeed())
+
+			By("By adding mixed labels to k8s PVC")
+			pvc.SetLabels(mixedLabels)
+			Eventually(func() error {
+				return k8sClient.Update(ctx, &pvc)
+			}, timeout, interval).Should(Succeed())
+
+			By("Expecting StorageOS Volume labels to match but not include defaults from storageclass")
+			Eventually(func() map[string]string {
+				vol, err := api.GetVolume(ctx, client.ObjectKey{Name: pvc.Spec.VolumeName, Namespace: pvc.GetNamespace()})
+				if err != nil {
+					return nil
+				}
+				return vol.GetLabels()
+			}, timeout, interval).Should(Equal(map[string]string{
+				"foo":                           "bar",
+				"baz":                           "boo",
+				storageos.ReservedLabelReplicas: "1",
+			}))
+		})
+	})
+
+	Context("When adding labels after deleting and recreating the storageclass", func() {
+		sc := genSC(true, nil)
+		scCopy := sc.DeepCopy()
+		key := SetupPVCLabelSyncTest(ctx, sc, sc.Name, true, true, nil, false)
+		It("Should sync labels to StorageOS Volume", func() {
+			By("Confirming PVC exists in k8s")
+			var pvc corev1.PersistentVolumeClaim
+			Expect(k8sClient.Get(ctx, key, &pvc)).Should(Succeed())
+
+			By("Deleting the StorageClass")
+			Expect(k8sClient.Delete(ctx, &sc, &client.DeleteOptions{})).Should(Succeed())
+
+			By("Creating a new StorageClass with the same name")
+			Expect(k8sClient.Create(ctx, scCopy, &client.CreateOptions{})).Should(Succeed())
+
+			By("By adding mixed labels to k8s PVC")
+			pvc.SetLabels(mixedLabels)
+			Eventually(func() error {
+				return k8sClient.Update(ctx, &pvc)
+			}, timeout, interval).Should(Succeed())
+
+			By("Expecting StorageOS Volume labels sync to fail")
+			Consistently(func() map[string]string {
+				vol, err := api.GetVolume(ctx, client.ObjectKey{Name: pvc.Spec.VolumeName, Namespace: pvc.GetNamespace()})
+				if err != nil {
+					return nil
+				}
+				return vol.GetLabels()
+			}, timeout, interval).Should(BeNil())
+		})
+	})
+
+	Context("When adding labels after deleting and recreating the storageclass and the pvc annotation has not been set", func() {
+		sc := genSC(true, nil)
+		scCopy := sc.DeepCopy()
+		key := SetupPVCLabelSyncTest(ctx, sc, sc.Name, true, false, nil, false)
+		It("Should sync labels to StorageOS Volume", func() {
+			By("Confirming PVC exists in k8s")
+			var pvc corev1.PersistentVolumeClaim
+			Expect(k8sClient.Get(ctx, key, &pvc)).Should(Succeed())
+
+			By("Deleting the StorageClass")
+			Expect(k8sClient.Delete(ctx, &sc, &client.DeleteOptions{})).Should(Succeed())
+
+			By("Creating a new StorageClass with the same name")
+			Expect(k8sClient.Create(ctx, scCopy, &client.CreateOptions{})).Should(Succeed())
+
+			By("By adding mixed labels to k8s PVC")
+			pvc.SetLabels(mixedLabels)
+			Eventually(func() error {
+				return k8sClient.Update(ctx, &pvc)
+			}, timeout, interval).Should(Succeed())
 
 			By("Expecting StorageOS Volume labels to match")
 			Eventually(func() map[string]string {

--- a/controllers/pvc_storageclass_test.go
+++ b/controllers/pvc_storageclass_test.go
@@ -1,0 +1,389 @@
+package controllers
+
+import (
+	"context"
+	"time"
+
+	"github.com/darkowlzz/operator-toolkit/webhook/cert"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	pvcmutator "github.com/storageos/api-manager/controllers/pvc-mutator"
+	"github.com/storageos/api-manager/controllers/pvc-mutator/storageclass"
+	"github.com/storageos/api-manager/internal/pkg/provisioner"
+)
+
+// Define utility constants for object names and testing timeouts and intervals.
+const (
+	storageClassTimeout  = time.Second * 1
+	storageClassInterval = time.Millisecond * 250
+)
+
+var (
+	stosDefaultStorageClassName    = "stos-default"
+	stosStorageClassName           = "stos"
+	nonStosDefaultStorageClassName = "non-stos-default"
+	nonStosStorageClassName        = "non-stos"
+)
+
+// SetupPVCStorageClassAnnotationTest will set up a testing environment.  It must be called
+// from each test.
+func SetupPVCStorageClassAnnotationTest(ctx context.Context, storageClasses ...storagev1.StorageClass) {
+	var cancel func()
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithCancel(ctx)
+
+		// Configure the certificate manager.
+		certOpts := cert.Options{
+			Service: &admissionv1.ServiceReference{
+				Name:      webhookServiceName,
+				Namespace: webhookServiceNamespace,
+			},
+			Client:                    k8sClient,
+			SecretRef:                 &types.NamespacedName{Name: webhookSecretName, Namespace: webhookSecretNamespace},
+			MutatingWebhookConfigRefs: []types.NamespacedName{{Name: webhookMutatingConfigName}},
+		}
+
+		err := cert.NewManager(nil, certOpts)
+		Expect(err).NotTo(HaveOccurred(), "unable to provision certificate")
+
+		webhookInstallOptions := &testEnv.WebhookInstallOptions
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Host:               webhookInstallOptions.LocalServingHost,
+			Port:               webhookInstallOptions.LocalServingPort,
+			CertDir:            webhookInstallOptions.LocalServingCertDir,
+			LeaderElection:     false,
+			MetricsBindAddress: "0",
+		})
+		Expect(err).NotTo(HaveOccurred(), "failed to create manager")
+
+		decoder, err := admission.NewDecoder(mgr.GetScheme())
+		Expect(err).NotTo(HaveOccurred(), "failed to create decoder")
+
+		pvcMutator := pvcmutator.NewController(mgr.GetClient(), decoder, []pvcmutator.Mutator{
+			storageclass.NewAnnotationSetter(mgr.GetClient()),
+		})
+
+		mgr.GetWebhookServer().Register(webhookMutatePVCsPath, &webhook.Admission{Handler: pvcMutator})
+		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
+
+		for _, sc := range storageClasses {
+			sc := sc
+			Expect(k8sClient.Create(ctx, &sc)).Should(Succeed())
+		}
+
+		go func() {
+			err := mgr.Start(ctx)
+			Expect(err).NotTo(HaveOccurred(), "failed to start manager")
+		}()
+
+		// Wait for manager to be ready.
+		time.Sleep(managerWaitDuration)
+	})
+
+	AfterEach(func() {
+		for _, sc := range storageClasses {
+			sc := sc
+			Expect(k8sClient.Delete(ctx, &sc)).Should(Succeed())
+		}
+
+		cancel()
+	})
+}
+
+var _ = Describe("The default StorageClass has not been configured", func() {
+	ctx := context.Background()
+
+	Context("When there is no given StorageClass", func() {
+		SetupPVCStorageClassAnnotationTest(ctx)
+
+		It("The pvc should not be created", func() {
+			By("Expecting the PVC has default StorageClass")
+			pvc := genPVC()
+
+			By("Creating the PVC")
+			Expect(k8sClient.Create(ctx, &pvc)).ShouldNot(Succeed())
+		})
+	})
+
+	Context("When the given StorageClass is non StorageOS", func() {
+		storageClass := getStorageClass(nonStosStorageClassName, false)
+
+		SetupPVCStorageClassAnnotationTest(ctx, storageClass)
+
+		It("The pvc should be created without annotation", func() {
+			pvc := genPVC()
+			pvc.Spec.StorageClassName = &storageClass.Name
+
+			By("Creating the PVC")
+			Expect(k8sClient.Create(ctx, &pvc)).Should(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
+			}()
+
+			By("Expecting the PVC has to be unchanged")
+			Consistently(func() corev1.PersistentVolumeClaim {
+				got := corev1.PersistentVolumeClaim{}
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &got)
+				if err != nil {
+					return corev1.PersistentVolumeClaim{}
+				}
+				return got
+			}, storageClassTimeout, storageClassInterval).Should(Equal(pvc))
+		})
+	})
+
+	Context("When the given StorageClass is StorageOS", func() {
+		storageClass := getStorageClass(stosStorageClassName, false)
+
+		SetupPVCStorageClassAnnotationTest(ctx, storageClass)
+
+		It("The pvc should be created with annotation", func() {
+			pvc := genPVC()
+			pvc.Spec.StorageClassName = &storageClass.Name
+
+			By("Creating the PVC")
+			Expect(k8sClient.Create(ctx, &pvc)).Should(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
+			}()
+
+			By("Fetching the StorageClass")
+			persistedSC := storagev1.StorageClass{}
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: storageClass.Name}, &persistedSC)
+			Expect(err).NotTo(HaveOccurred(), "failed to fetch StorageClass")
+
+			By("Expecting the PVC to be patched")
+			Eventually(func() string {
+				var mutatedPVC corev1.PersistentVolumeClaim
+
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &mutatedPVC)
+				if err != nil {
+					return ""
+				}
+
+				return mutatedPVC.Annotations[provisioner.StorageClassUUIDAnnotationKey]
+			}, storageClassTimeout, storageClassInterval).Should(Equal(string(persistedSC.UID)))
+		})
+	})
+})
+
+var _ = Describe("The default StorageClass is not StorageOS", func() {
+	ctx := context.Background()
+
+	Context("When there is no given StorageClass", func() {
+		defaultStorageClass := getStorageClass(nonStosDefaultStorageClassName, true)
+
+		SetupPVCStorageClassAnnotationTest(ctx, defaultStorageClass)
+
+		It("The pvc should be created without annotation", func() {
+			pvc := genPVC()
+
+			By("Creating the PVC")
+			Expect(k8sClient.Create(ctx, &pvc)).Should(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
+			}()
+
+			By("Expecting the PVC has to be unchanged")
+			Consistently(func() corev1.PersistentVolumeClaim {
+				got := corev1.PersistentVolumeClaim{}
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &got)
+				if err != nil {
+					return corev1.PersistentVolumeClaim{}
+				}
+				return got
+			}, storageClassTimeout, storageClassInterval).Should(Equal(pvc))
+		})
+	})
+
+	Context("When the given StorageClass is not StorageOS", func() {
+		defaultStorageClass := getStorageClass(nonStosDefaultStorageClassName, true)
+		storageClass := getStorageClass(nonStosStorageClassName, false)
+
+		SetupPVCStorageClassAnnotationTest(ctx, defaultStorageClass, storageClass)
+
+		It("The pvc should be created without annotation", func() {
+			pvc := genPVC()
+			pvc.Spec.StorageClassName = &storageClass.Name
+
+			By("Creating the PVC")
+			Expect(k8sClient.Create(ctx, &pvc)).Should(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
+			}()
+
+			By("Expecting the PVC has to be unchanged")
+			Consistently(func() corev1.PersistentVolumeClaim {
+				got := corev1.PersistentVolumeClaim{}
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &got)
+				if err != nil {
+					return corev1.PersistentVolumeClaim{}
+				}
+				return got
+			}, storageClassTimeout, storageClassInterval).Should(Equal(pvc))
+		})
+	})
+
+	Context("When the given StorageClass is StorageOS", func() {
+		defaultStorageClass := getStorageClass(nonStosDefaultStorageClassName, true)
+		storageClass := getStorageClass(stosStorageClassName, false)
+
+		SetupPVCStorageClassAnnotationTest(ctx, defaultStorageClass, storageClass)
+
+		It("The pvc should be created with annotation", func() {
+			pvc := genPVC()
+			pvc.Spec.StorageClassName = &storageClass.Name
+
+			By("Creating the PVC")
+			Expect(k8sClient.Create(ctx, &pvc)).Should(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
+			}()
+
+			By("Fetching the StorageClass")
+			persistedSC := storagev1.StorageClass{}
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: storageClass.Name}, &persistedSC)
+			Expect(err).NotTo(HaveOccurred(), "failed to fetch StorageClass")
+
+			By("Expecting the PVC to be patched")
+			Eventually(func() string {
+				var mutatedPVC corev1.PersistentVolumeClaim
+
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &mutatedPVC)
+				if err != nil {
+					return ""
+				}
+
+				return mutatedPVC.Annotations[provisioner.StorageClassUUIDAnnotationKey]
+			}, storageClassTimeout, storageClassInterval).Should(Equal(string(persistedSC.UID)))
+		})
+	})
+})
+
+var _ = Describe("The default StorageClass is StorageOS", func() {
+	ctx := context.Background()
+
+	Context("When there is no given StorageClass", func() {
+		defaultStorageClass := getStorageClass(stosDefaultStorageClassName, true)
+
+		SetupPVCStorageClassAnnotationTest(ctx, defaultStorageClass)
+
+		It("The pvc should be created with annotation", func() {
+			pvc := genPVC()
+
+			By("Creating the PVC")
+			Expect(k8sClient.Create(ctx, &pvc)).Should(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
+			}()
+
+			By("Fetching the StorageClass")
+			persistedSC := storagev1.StorageClass{}
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: defaultStorageClass.Name}, &persistedSC)
+			Expect(err).NotTo(HaveOccurred(), "failed to fetch StorageClass")
+
+			By("Expecting the PVC to be patched")
+			Eventually(func() string {
+				var mutatedPVC corev1.PersistentVolumeClaim
+
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &mutatedPVC)
+				if err != nil {
+					return ""
+				}
+
+				return mutatedPVC.Annotations[provisioner.StorageClassUUIDAnnotationKey]
+			}, storageClassTimeout, storageClassInterval).Should(Equal(string(persistedSC.UID)))
+		})
+	})
+
+	Context("When the given StorageClass is not StorageOS", func() {
+		defaultStorageClass := getStorageClass(stosDefaultStorageClassName, true)
+		storageClass := getStorageClass(nonStosStorageClassName, false)
+
+		SetupPVCStorageClassAnnotationTest(ctx, defaultStorageClass, storageClass)
+
+		It("The pvc should be created without annotation", func() {
+			pvc := genPVC()
+			pvc.Spec.StorageClassName = &storageClass.Name
+
+			By("Creating the PVC")
+			Expect(k8sClient.Create(ctx, &pvc)).Should(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
+			}()
+
+			By("Expecting the PVC has to be unchanged")
+			Consistently(func() corev1.PersistentVolumeClaim {
+				got := corev1.PersistentVolumeClaim{}
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &got)
+				if err != nil {
+					return corev1.PersistentVolumeClaim{}
+				}
+				return got
+			}, storageClassTimeout, storageClassInterval).Should(Equal(pvc))
+		})
+	})
+
+	Context("When the given StorageClass is StorageOS", func() {
+		defaultStorageClass := getStorageClass(stosDefaultStorageClassName, true)
+		storageClass := getStorageClass(stosStorageClassName, false)
+
+		SetupPVCStorageClassAnnotationTest(ctx, defaultStorageClass, storageClass)
+
+		It("The pvc should be created with annotation", func() {
+			pvc := genPVC()
+			pvc.Spec.StorageClassName = &storageClass.Name
+
+			By("Creating the PVC")
+			Expect(k8sClient.Create(ctx, &pvc)).Should(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
+			}()
+
+			By("Fetching the StorageClass")
+			persistedSC := storagev1.StorageClass{}
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: storageClass.Name}, &persistedSC)
+			Expect(err).NotTo(HaveOccurred(), "failed to fetch StorageClass")
+
+			By("Expecting the PVC to be patched")
+			Eventually(func() string {
+				var mutatedPVC corev1.PersistentVolumeClaim
+
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &mutatedPVC)
+				if err != nil {
+					return ""
+				}
+
+				return mutatedPVC.Annotations[provisioner.StorageClassUUIDAnnotationKey]
+			}, storageClassTimeout, storageClassInterval).Should(Equal(string(persistedSC.UID)))
+		})
+	})
+})
+
+func getStorageClass(name string, isDefault bool) storagev1.StorageClass {
+	sc := storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Provisioner: provisioner.DriverName,
+	}
+
+	if isDefault {
+		sc.Annotations = map[string]string{
+			provisioner.DefaultStorageClassKey: "true",
+		}
+	}
+
+	return sc
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -10,6 +10,9 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap/zapcore"
 	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -109,4 +112,21 @@ func randStringRunes(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+func genPVC() corev1.PersistentVolumeClaim {
+	return corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-" + randStringRunes(5),
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.PersistentVolumeAccessMode("ReadWriteOnce")},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
 }

--- a/internal/pkg/provisioner/storageclass.go
+++ b/internal/pkg/provisioner/storageclass.go
@@ -17,9 +17,9 @@ const (
 	// still be checked as k8s still supports it.
 	pvcStorageClassKey = "volume.beta.kubernetes.io/storage-class"
 
-	// defaultStorageClassKey is the annotation used to denote whether a
+	// DefaultStorageClassKey is the annotation used to denote whether a
 	// StorageClass is the cluster default.
-	defaultStorageClassKey = "storageclass.kubernetes.io/is-default-class"
+	DefaultStorageClassKey = "storageclass.kubernetes.io/is-default-class"
 
 	// StorageClassUUIDAnnotationKey is the annotation on the PVC that stores
 	// the UUID of the StorageClass that was used to provision it.  It is used
@@ -65,7 +65,7 @@ func DefaultStorageClass(k8s client.Client) (*storagev1.StorageClass, error) {
 		return nil, fmt.Errorf("failed to get StorageClasses: %v", err)
 	}
 	for _, sc := range scList.Items {
-		if val, ok := sc.Annotations[defaultStorageClassKey]; ok && val == "true" {
+		if val, ok := sc.Annotations[DefaultStorageClassKey]; ok && val == "true" {
 			return &sc, nil
 		}
 	}

--- a/internal/pkg/provisioner/storageclass.go
+++ b/internal/pkg/provisioner/storageclass.go
@@ -3,6 +3,7 @@ package provisioner
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -19,21 +20,40 @@ const (
 	// defaultStorageClassKey is the annotation used to denote whether a
 	// StorageClass is the cluster default.
 	defaultStorageClassKey = "storageclass.kubernetes.io/is-default-class"
+
+	// StorageClassUUIDAnnotationKey is the annotation on the PVC that stores
+	// the UUID of the StorageClass that was used to provision it.  It is used
+	// to detect when the StorageClass was deleted and re-created with the same
+	// name.
+	StorageClassUUIDAnnotationKey = "storageos.com/storageclass"
+
+	// reservedParamPrefix is the prefix used to determine whether a parameter
+	// should be considered "reserved" by StorageOS.
+	reservedParamPrefix = "storageos.com/"
 )
 
 // StorageClassForPVC returns the StorageClass of the PVC.  If no StorageClass
 // was specified, returns the cluster default if set.
 func StorageClassForPVC(k8s client.Client, pvc *corev1.PersistentVolumeClaim) (*storagev1.StorageClass, error) {
-	scName := PVCStorageClassName(pvc)
-	if scName == "" {
+	name := PVCStorageClassName(pvc)
+	if name == "" {
 		return DefaultStorageClass(k8s)
 	}
-	sc := &storagev1.StorageClass{}
-	scNSName := types.NamespacedName{
-		Name: scName,
+	return StorageClass(k8s, name)
+}
+
+// StorageClass returns the StorageClass matching the name.  If no name was
+// specified, the default StorageClass (if any) is returned instead.
+func StorageClass(k8s client.Client, name string) (*storagev1.StorageClass, error) {
+	if name == "" {
+		return DefaultStorageClass(k8s)
 	}
-	if err := k8s.Get(context.Background(), scNSName, sc); err != nil {
-		return nil, fmt.Errorf("failed to get StorageClass: %v", err)
+	key := types.NamespacedName{
+		Name: name,
+	}
+	sc := &storagev1.StorageClass{}
+	if err := k8s.Get(context.Background(), key, sc); err != nil {
+		return nil, fmt.Errorf("failed to get StorageClass: %w", err)
 	}
 	return sc, nil
 }
@@ -63,4 +83,45 @@ func PVCStorageClassName(pvc *corev1.PersistentVolumeClaim) string {
 		return val
 	}
 	return ""
+}
+
+// StorageClassReservedParams returns a map of StorageClass parameters that are
+// reserved for StorageOS.  These are typically feature defaults for any volumes
+// provisioned by the StorageClass.
+func StorageClassReservedParams(sc *storagev1.StorageClass) map[string]string {
+	reserved := make(map[string]string)
+	for k, v := range sc.Parameters {
+		if strings.HasPrefix(k, reservedParamPrefix) {
+			reserved[k] = v
+		}
+	}
+	return reserved
+}
+
+// ValidateOrSetStorageClassUID returns true if the StorageClass annotation on
+// the PVC object matches the uid passed in.
+//
+// If the annotation does not exist, it sets the uid passed in as the new
+// StorageClass annotation.
+func ValidateOrSetStorageClassUID(ctx context.Context, k8s client.Client, uid types.UID, obj client.Object) (bool, error) {
+	provisionedUID := obj.GetAnnotations()[StorageClassUUIDAnnotationKey]
+	if provisionedUID != "" {
+		return string(uid) == provisionedUID, nil
+	}
+
+	// Annotation not set, set it.
+	if err := SetStorageClassUIDAnnotation(ctx, k8s, uid, obj); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// SetStorageClassUIDAnnotation adds the StorageClass annotation to a PVC object.
+func SetStorageClassUIDAnnotation(ctx context.Context, k8s client.Client, uid types.UID, obj client.Object) error {
+	var pvc corev1.PersistentVolumeClaim
+	if err := k8s.Get(ctx, client.ObjectKeyFromObject(obj), &pvc); err != nil {
+		return err
+	}
+	pvc.Annotations[StorageClassUUIDAnnotationKey] = string(uid)
+	return k8s.Update(ctx, &pvc, &client.UpdateOptions{})
 }

--- a/internal/pkg/provisioner/storageos.go
+++ b/internal/pkg/provisioner/storageos.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -90,16 +91,21 @@ func IsProvisionedPVC(k8s client.Client, pvc corev1.PersistentVolumeClaim, names
 		return false, err
 	}
 
+	return IsProvisionedStorageClass(sc, provisioners...), nil
+}
+
+// IsProvisionedStorageClass returns true if the StorageClass has one of the given provisioners.
+func IsProvisionedStorageClass(sc *storagev1.StorageClass, provisioners ...string) bool {
 	// Check if the StorageClass provisioner matches with any of the provided
 	// provisioners.
 	for _, provisioner := range provisioners {
 		if sc.Provisioner == provisioner {
-			// This is a managed volume.
-			return true, nil
+			// Provisoned by one of the provisioners
+			return true
 		}
 	}
 
-	return false, nil
+	return false
 }
 
 // IsStorageOSVolume returns true if the volume's PVC was provisioned by

--- a/internal/pkg/provisioner/storageos_test.go
+++ b/internal/pkg/provisioner/storageos_test.go
@@ -301,6 +301,39 @@ func TestIsProvisionedPVC(t *testing.T) {
 	}
 }
 
+func TestIsProvisionedStorageClass(t *testing.T) {
+	provisioner := DriverName
+
+	testcases := []struct {
+		name            string
+		storageClass    storagev1.StorageClass
+		wantProvisioned bool
+	}{
+		{
+			name:         "not-provisioned",
+			storageClass: storagev1.StorageClass{},
+		},
+		{
+			name: "provisioned",
+			storageClass: storagev1.StorageClass{
+				Provisioner: provisioner,
+			},
+			wantProvisioned: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			isProvisioned := IsProvisionedStorageClass(&tc.storageClass, provisioner)
+
+			if isProvisioned != tc.wantProvisioned {
+				t.Errorf("provisoned flag got:\n%t\n, want:\n%t", isProvisioned, tc.wantProvisioned)
+			}
+		})
+	}
+}
+
 // createPVC creates and returns a PVC object.
 func createPVC(name, namespace, storageClassName string, betaAnnotation bool) corev1.PersistentVolumeClaim {
 	pvc := corev1.PersistentVolumeClaim{

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ import (
 	pvclabel "github.com/storageos/api-manager/controllers/pvc-label"
 	pvcmutator "github.com/storageos/api-manager/controllers/pvc-mutator"
 	"github.com/storageos/api-manager/controllers/pvc-mutator/encryption"
+	"github.com/storageos/api-manager/controllers/pvc-mutator/storageclass"
 	"github.com/storageos/api-manager/internal/controllers/sharedvolume"
 	"github.com/storageos/api-manager/internal/pkg/cluster"
 	"github.com/storageos/api-manager/internal/pkg/labels"
@@ -337,6 +338,7 @@ func main() {
 
 	pvcMutator := pvcmutator.NewController(mgr.GetClient(), decoder, []pvcmutator.Mutator{
 		encryption.NewKeySetter(mgr.GetClient(), uncachedClient, labels.Default()),
+		storageclass.NewAnnotationSetter(mgr.GetClient()),
 	})
 	mgr.GetWebhookServer().Register(webhookMutatePVCsPath, &webhook.Admission{Handler: pvcMutator})
 


### PR DESCRIPTION
Prior to applying labels after a change has been detected, defaults are loaded from the StorageClass parameters that provisioned the volume.  This ensures that the defaults set in the StorageClass are not overwritten because there is not a corresponding label on the PVC.

Since StorageClasses are immutable the params can't be changed after the volume has been provisioned.  To protect against the SC being deleted and re-added with different params, a reference to the original SC's UID is stored in an annotation on the PVC.  If the current SC does not match, an error is logged and label sync is disabled for that PVC.