### PR TITLE
Use composite client in admission controllers

### DIFF
--- a/controllers/pvc-mutator/encryption/keygen.go
+++ b/controllers/pvc-mutator/encryption/keygen.go
@@ -79,14 +79,14 @@ type EncryptionKeySetter struct {
 // NewKeySetter returns a new PVC encryption key mutating admission
 // controller that generates volume encryption keys and sets references to their
 // location as PVC annotations.
-func NewKeySetter(k8s client.Client, uncached client.Client, labels map[string]string) *EncryptionKeySetter {
+func NewKeySetter(k8s client.Client, labels map[string]string) *EncryptionKeySetter {
 	return &EncryptionKeySetter{
 		enabledLabel:                 storageos.ReservedLabelEncryption,
 		secretNameAnnotationKey:      SecretNameAnnotationKey,
 		secretNamespaceAnnotationKey: SecretNamespaceAnnotationKey,
 
 		Client: k8s,
-		keys:   keys.New(uncached),
+		keys:   keys.New(k8s),
 		labels: labels,
 		log:    ctrl.Log.WithName("keygen"),
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/storageos/api-manager
 go 1.16
 
 require (
-	github.com/darkowlzz/operator-toolkit v0.0.0-20210417061919-7030a782a07c
+	github.com/darkowlzz/operator-toolkit v0.0.0-20210426100703-6262535ea515
 	github.com/go-logr/logr v0.3.0
 	github.com/golang/mock v1.5.0
 	github.com/google/uuid v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/darkowlzz/operator-toolkit v0.0.0-20210417061919-7030a782a07c h1:GJxpmlPvfK4Vl5cuRRPm+H0KTHNp//l0Sphjwo+cw2w=
-github.com/darkowlzz/operator-toolkit v0.0.0-20210417061919-7030a782a07c/go.mod h1:vTbpGBAPaoQcxeRgQtF7AVM5ms7CMszjEx2AJ7ylSu0=
+github.com/darkowlzz/operator-toolkit v0.0.0-20210426100703-6262535ea515 h1:RTRnqEo9AFK6gb5G3MpdXz1zmvUw3uCWULJ1WUMEVrw=
+github.com/darkowlzz/operator-toolkit v0.0.0-20210426100703-6262535ea515/go.mod h1:vTbpGBAPaoQcxeRgQtF7AVM5ms7CMszjEx2AJ7ylSu0=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/vendor/github.com/darkowlzz/operator-toolkit/client/composite/client.go
+++ b/vendor/github.com/darkowlzz/operator-toolkit/client/composite/client.go
@@ -1,0 +1,68 @@
+package composite
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// Client is a composite client, composed of cached and uncached clients. It
+// can be used to query objects from cache and fall back to use the raw client
+// and get the object directly from the API server when there's a cache miss.
+type Client struct {
+	client.Client
+	Options
+
+	uncached client.Client
+}
+
+// ClientOption is used to configure the client.
+type Options struct {
+	// RawListing is used to perform raw listing operations, uncached.
+	RawListing bool
+}
+
+// NewClient creates and returns a composite Client.
+func NewClient(cached client.Client, uncached client.Client, opts Options) *Client {
+	return &Client{
+		Client:   cached,
+		Options:  opts,
+		uncached: uncached,
+	}
+}
+
+// NewClientFromManager combines a cached and an uncached client to return a
+// composite client. The default cache returned by the controller manager is a
+// cached client.
+func NewClientFromManager(mgr manager.Manager, opts Options) (client.Client, error) {
+	uncachedClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
+	if err != nil {
+		return nil, err
+	}
+
+	return NewClient(mgr.GetClient(), uncachedClient, opts), nil
+}
+
+// Get first fetches the object using the cached client. If the object is not
+// found in the cached client, it retries using the uncached client.
+func (c *Client) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	if cErr := c.Client.Get(ctx, key, obj); cErr != nil {
+		// If not found in the cache, try with the uncached client.
+		if apierrors.IsNotFound(cErr) {
+			return c.uncached.Get(ctx, key, obj)
+		}
+		return cErr
+	}
+	return nil
+}
+
+// List lists the objects based on the client configuration. If RawListing is
+// true, it uses the uncached client to list, else it uses the cached client.
+func (c *Client) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if c.RawListing {
+		return c.uncached.List(ctx, list, opts...)
+	}
+	return c.Client.List(ctx, list, opts...)
+}

--- a/vendor/github.com/darkowlzz/operator-toolkit/client/composite/doc.go
+++ b/vendor/github.com/darkowlzz/operator-toolkit/client/composite/doc.go
@@ -1,0 +1,10 @@
+// Package composite provides a k8s client composed of a cached and an uncached
+// client.
+// For Get operations, the cache is used, in case the target object isn't
+// available in the cache, the client will perform a GET call using the
+// uncached client to get the object directly from the k8s api server.
+// For List operations, the client can be configured to use the cache or
+// directly list from the k8s api server. Unlike Get, List does not return
+// error when objects are not found. It returns an empty list. The decision to
+// retry without cache can't be made for List operations.
+package composite

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,8 +8,9 @@ github.com/apache/thrift/lib/go/thrift
 github.com/beorn7/perks/quantile
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
-# github.com/darkowlzz/operator-toolkit v0.0.0-20210417061919-7030a782a07c
+# github.com/darkowlzz/operator-toolkit v0.0.0-20210426100703-6262535ea515
 ## explicit
+github.com/darkowlzz/operator-toolkit/client/composite
 github.com/darkowlzz/operator-toolkit/controller/external-object-sync/v1
 github.com/darkowlzz/operator-toolkit/controller/external/builder
 github.com/darkowlzz/operator-toolkit/controller/external/cache


### PR DESCRIPTION
This change replaces all the cached/uncached clients in admission
controllers with a composite client. The composite client will help
handle the cases where the cached client can't find the recently
created resources. The composite client will retry the query using
the raw client to query the k8s API server directly.

Refer https://pkg.go.dev/github.com/darkowlzz/operator-toolkit@v0.0.0-20210423182126-723c7a1e8b45/client/composite for details about the composite client.