### PR TITLE
Fix storageclass annotation int. tests

### DIFF
--- a/controllers/pvc_storageclass_test.go
+++ b/controllers/pvc_storageclass_test.go
@@ -139,7 +139,7 @@ var _ = Describe("The default StorageClass has not been configured", func() {
 				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
 			}()
 
-			By("Expecting the PVC hasn't annotated with StorageClass")
+			By("Expecting the PVC not to have the StorageClass annotation")
 			// The create operation mutates the PVC, so the testcase has
 			// reference only to the final version. Only annotations could be tested.
 			Consistently(func() string {
@@ -174,7 +174,7 @@ var _ = Describe("The default StorageClass has not been configured", func() {
 			err := k8sClient.Get(ctx, client.ObjectKey{Name: storageClass.Name}, &persistedSC)
 			Expect(err).NotTo(HaveOccurred(), "failed to fetch StorageClass")
 
-			By("Expecting the PVC has annotated with StorageClass")
+			By("Expecting the PVC has the StorageClass annotation")
 			// The create operation mutates the PVC, so the testcase has
 			// reference only to the final version. Only annotations could be tested.
 			Eventually(func() string {
@@ -208,7 +208,7 @@ var _ = Describe("The default StorageClass is not StorageOS", func() {
 				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
 			}()
 
-			By("Expecting the PVC hasn't annotated with StorageClass")
+			By("Expecting the PVC not to have the StorageClass annotation")
 			// The create operation mutates the PVC, so the testcase has
 			// reference only to the final version. Only annotations could be tested.
 			Consistently(func() string {
@@ -239,7 +239,7 @@ var _ = Describe("The default StorageClass is not StorageOS", func() {
 				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
 			}()
 
-			By("Expecting the PVC hasn't annotated with StorageClass")
+			By("Expecting the PVC not to have the StorageClass annotation")
 			// The create operation mutates the PVC, so the testcase has
 			// reference only to the final version. Only annotations could be tested.
 			Consistently(func() string {
@@ -275,7 +275,7 @@ var _ = Describe("The default StorageClass is not StorageOS", func() {
 			err := k8sClient.Get(ctx, client.ObjectKey{Name: storageClass.Name}, &persistedSC)
 			Expect(err).NotTo(HaveOccurred(), "failed to fetch StorageClass")
 
-			By("Expecting the PVC has annotated with StorageClass")
+			By("Expecting the PVC has the StorageClass annotation")
 			// The create operation mutates the PVC, so the testcase has
 			// reference only to the final version. Only annotations could be tested.
 			Eventually(func() string {
@@ -314,7 +314,7 @@ var _ = Describe("The default StorageClass is StorageOS", func() {
 			err := k8sClient.Get(ctx, client.ObjectKey{Name: defaultStorageClass.Name}, &persistedSC)
 			Expect(err).NotTo(HaveOccurred(), "failed to fetch StorageClass")
 
-			By("Expecting the PVC has annotated with StorageClass")
+			By("Expecting the PVC has the StorageClass annotation")
 			// The create operation mutates the PVC, so the testcase has
 			// reference only to the final version. Only annotations could be tested.
 			Eventually(func() string {
@@ -346,7 +346,7 @@ var _ = Describe("The default StorageClass is StorageOS", func() {
 				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
 			}()
 
-			By("Expecting the PVC hasn't annotated with StorageClass")
+			By("Expecting the PVC not to have the StorageClass annotation")
 			// The create operation mutates the PVC, so the testcase has
 			// reference only to the final version. Only annotations could be tested.
 			Consistently(func() string {
@@ -382,7 +382,7 @@ var _ = Describe("The default StorageClass is StorageOS", func() {
 			err := k8sClient.Get(ctx, client.ObjectKey{Name: storageClass.Name}, &persistedSC)
 			Expect(err).NotTo(HaveOccurred(), "failed to fetch StorageClass")
 
-			By("Expecting the PVC has annotated with StorageClass")
+			By("Expecting the PVC has the StorageClass annotation")
 			// The create operation mutates the PVC, so the testcase has
 			// reference only to the final version. Only annotations could be tested.
 			Eventually(func() string {

--- a/controllers/pvc_storageclass_test.go
+++ b/controllers/pvc_storageclass_test.go
@@ -140,6 +140,8 @@ var _ = Describe("The default StorageClass has not been configured", func() {
 			}()
 
 			By("Expecting the PVC hasn't annotated with StorageClass")
+			// The create operation mutates the PVC, so the testcase has
+			// reference only to the final version. Only annotations could be tested.
 			Consistently(func() string {
 				got := corev1.PersistentVolumeClaim{}
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &got)
@@ -173,6 +175,8 @@ var _ = Describe("The default StorageClass has not been configured", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to fetch StorageClass")
 
 			By("Expecting the PVC has annotated with StorageClass")
+			// The create operation mutates the PVC, so the testcase has
+			// reference only to the final version. Only annotations could be tested.
 			Eventually(func() string {
 				var mutatedPVC corev1.PersistentVolumeClaim
 
@@ -205,6 +209,8 @@ var _ = Describe("The default StorageClass is not StorageOS", func() {
 			}()
 
 			By("Expecting the PVC hasn't annotated with StorageClass")
+			// The create operation mutates the PVC, so the testcase has
+			// reference only to the final version. Only annotations could be tested.
 			Consistently(func() string {
 				got := corev1.PersistentVolumeClaim{}
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &got)
@@ -234,6 +240,8 @@ var _ = Describe("The default StorageClass is not StorageOS", func() {
 			}()
 
 			By("Expecting the PVC hasn't annotated with StorageClass")
+			// The create operation mutates the PVC, so the testcase has
+			// reference only to the final version. Only annotations could be tested.
 			Consistently(func() string {
 				got := corev1.PersistentVolumeClaim{}
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &got)
@@ -268,6 +276,8 @@ var _ = Describe("The default StorageClass is not StorageOS", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to fetch StorageClass")
 
 			By("Expecting the PVC has annotated with StorageClass")
+			// The create operation mutates the PVC, so the testcase has
+			// reference only to the final version. Only annotations could be tested.
 			Eventually(func() string {
 				var mutatedPVC corev1.PersistentVolumeClaim
 
@@ -305,6 +315,8 @@ var _ = Describe("The default StorageClass is StorageOS", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to fetch StorageClass")
 
 			By("Expecting the PVC has annotated with StorageClass")
+			// The create operation mutates the PVC, so the testcase has
+			// reference only to the final version. Only annotations could be tested.
 			Eventually(func() string {
 				var mutatedPVC corev1.PersistentVolumeClaim
 
@@ -335,6 +347,8 @@ var _ = Describe("The default StorageClass is StorageOS", func() {
 			}()
 
 			By("Expecting the PVC hasn't annotated with StorageClass")
+			// The create operation mutates the PVC, so the testcase has
+			// reference only to the final version. Only annotations could be tested.
 			Consistently(func() string {
 				got := corev1.PersistentVolumeClaim{}
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &got)
@@ -369,6 +383,8 @@ var _ = Describe("The default StorageClass is StorageOS", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to fetch StorageClass")
 
 			By("Expecting the PVC has annotated with StorageClass")
+			// The create operation mutates the PVC, so the testcase has
+			// reference only to the final version. Only annotations could be tested.
 			Eventually(func() string {
 				var mutatedPVC corev1.PersistentVolumeClaim
 

--- a/controllers/pvc_storageclass_test.go
+++ b/controllers/pvc_storageclass_test.go
@@ -139,12 +139,12 @@ var _ = Describe("The default StorageClass has not been configured", func() {
 				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
 			}()
 
-			By("Expecting the PVC has to be unchanged")
+			By("Expecting the PVC hasn't annotated with StorageClass")
 			Consistently(func() string {
 				got := corev1.PersistentVolumeClaim{}
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &got)
 				if err != nil {
-					return "kube get error"
+					return err.Error()
 				}
 
 				return got.Annotations[provisioner.StorageClassUUIDAnnotationKey]
@@ -172,7 +172,7 @@ var _ = Describe("The default StorageClass has not been configured", func() {
 			err := k8sClient.Get(ctx, client.ObjectKey{Name: storageClass.Name}, &persistedSC)
 			Expect(err).NotTo(HaveOccurred(), "failed to fetch StorageClass")
 
-			By("Expecting the PVC to be patched")
+			By("Expecting the PVC has annotated with StorageClass")
 			Eventually(func() string {
 				var mutatedPVC corev1.PersistentVolumeClaim
 
@@ -204,12 +204,12 @@ var _ = Describe("The default StorageClass is not StorageOS", func() {
 				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
 			}()
 
-			By("Expecting the PVC has to be unchanged")
+			By("Expecting the PVC hasn't annotated with StorageClass")
 			Consistently(func() string {
 				got := corev1.PersistentVolumeClaim{}
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &got)
 				if err != nil {
-					return "kube get error"
+					return err.Error()
 				}
 
 				return got.Annotations[provisioner.StorageClassUUIDAnnotationKey]
@@ -233,12 +233,12 @@ var _ = Describe("The default StorageClass is not StorageOS", func() {
 				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
 			}()
 
-			By("Expecting the PVC has to be unchanged")
+			By("Expecting the PVC hasn't annotated with StorageClass")
 			Consistently(func() string {
 				got := corev1.PersistentVolumeClaim{}
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &got)
 				if err != nil {
-					return "kube get error"
+					return err.Error()
 				}
 
 				return got.Annotations[provisioner.StorageClassUUIDAnnotationKey]
@@ -267,7 +267,7 @@ var _ = Describe("The default StorageClass is not StorageOS", func() {
 			err := k8sClient.Get(ctx, client.ObjectKey{Name: storageClass.Name}, &persistedSC)
 			Expect(err).NotTo(HaveOccurred(), "failed to fetch StorageClass")
 
-			By("Expecting the PVC to be patched")
+			By("Expecting the PVC has annotated with StorageClass")
 			Eventually(func() string {
 				var mutatedPVC corev1.PersistentVolumeClaim
 
@@ -304,7 +304,7 @@ var _ = Describe("The default StorageClass is StorageOS", func() {
 			err := k8sClient.Get(ctx, client.ObjectKey{Name: defaultStorageClass.Name}, &persistedSC)
 			Expect(err).NotTo(HaveOccurred(), "failed to fetch StorageClass")
 
-			By("Expecting the PVC to be patched")
+			By("Expecting the PVC has annotated with StorageClass")
 			Eventually(func() string {
 				var mutatedPVC corev1.PersistentVolumeClaim
 
@@ -320,7 +320,7 @@ var _ = Describe("The default StorageClass is StorageOS", func() {
 
 	Context("When the given StorageClass is not StorageOS", func() {
 		defaultStorageClass := getStorageClass(stosDefaultStorageClassName, provisioner.DriverName, true)
-		storageClass := getStorageClass(nonStosStorageClassName, "foo-provisioner", false)
+		storageClass := getStorageClass(nonStosStorageClassName, nonStosProvisioner, false)
 
 		SetupPVCStorageClassAnnotationTest(ctx, defaultStorageClass, storageClass)
 
@@ -334,12 +334,12 @@ var _ = Describe("The default StorageClass is StorageOS", func() {
 				Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
 			}()
 
-			By("Expecting the PVC has to be unchanged")
+			By("Expecting the PVC hasn't annotated with StorageClass")
 			Consistently(func() string {
 				got := corev1.PersistentVolumeClaim{}
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &got)
 				if err != nil {
-					return "kube get error"
+					return err.Error()
 				}
 
 				return got.Annotations[provisioner.StorageClassUUIDAnnotationKey]
@@ -368,7 +368,7 @@ var _ = Describe("The default StorageClass is StorageOS", func() {
 			err := k8sClient.Get(ctx, client.ObjectKey{Name: storageClass.Name}, &persistedSC)
 			Expect(err).NotTo(HaveOccurred(), "failed to fetch StorageClass")
 
-			By("Expecting the PVC to be patched")
+			By("Expecting the PVC has annotated with StorageClass")
 			Eventually(func() string {
 				var mutatedPVC corev1.PersistentVolumeClaim
 


### PR DESCRIPTION
Previously the test compared the entire PVC with itself on case of "changes not needed" which doesn't make much sense and because there was a misconfiguration in test cases this was hidden. I fixed the config and decrease the scope of comparison. 