### PR TITLE
Check encryption flag in storage class

### DIFF
--- a/controllers/pvc-mutator/encryption/keygen.go
+++ b/controllers/pvc-mutator/encryption/keygen.go
@@ -120,7 +120,7 @@ func (s *EncryptionKeySetter) MutatePVC(ctx context.Context, pvc *corev1.Persist
 	// Invalid value of encryption must block PVC creation.
 	enabled, err := s.isEnabled(pvc.GetLabels(), storageClass.Parameters)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to parse %q option for PVC", s.enabledLabel))
+		return errors.Wrap(err, fmt.Sprintf("failed to parse boolean value for %q pvc label or storageclass parameter", s.enabledLabel))
 	}
 	if !enabled {
 		log.V(4).Info("pvc does not have encryption enabled, skipping")

--- a/controllers/pvc-mutator/encryption/keygen.go
+++ b/controllers/pvc-mutator/encryption/keygen.go
@@ -120,7 +120,7 @@ func (s *EncryptionKeySetter) MutatePVC(ctx context.Context, pvc *corev1.Persist
 	// Invalid value of encryption must block PVC creation.
 	enabled, err := s.isEnabled(pvc.GetLabels(), storageClass.Parameters)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to parse boolean value of %s pvc", s.enabledLabel))
+		return errors.Wrap(err, fmt.Sprintf("failed to parse boolean value of %q pvc", s.enabledLabel))
 	}
 	if !enabled {
 		log.V(4).Info("pvc does not have encryption enabled, skipping")
@@ -220,7 +220,7 @@ func GenerateVolumeSecretName() string {
 	return fmt.Sprintf("%s-%s", VolumeSecretNamePrefix, uuid.New().String())
 }
 
-// isEnabled iterates on given maps and looks for encryption key. First occurence wins.
+// isEnabled iterates on the given maps and looks for encryption key. First occurrence wins
 func (s *EncryptionKeySetter) isEnabled(hayStacks ...map[string]string) (bool, error) {
 	for _, hayStack := range hayStacks {
 		val, exists := hayStack[s.enabledLabel]

--- a/controllers/pvc-mutator/encryption/keygen.go
+++ b/controllers/pvc-mutator/encryption/keygen.go
@@ -107,7 +107,7 @@ func (s *EncryptionKeySetter) MutatePVC(ctx context.Context, pvc *corev1.Persist
 		return errors.Wrap(err, "failed to retrieve storageclass of pvc")
 	}
 
-	// Skip mutation if the PVC is not provisioned by StorageOS
+	// Skip mutation if the PVC is not provisioned by StorageOS.
 	provisioned := provisioner.IsProvisionedStorageClass(storageClass, provisioner.DriverName)
 	if !provisioned {
 		log.V(4).Info("pvc will not be provisioned by StorageOS, skipping")

--- a/controllers/pvc-mutator/encryption/keygen.go
+++ b/controllers/pvc-mutator/encryption/keygen.go
@@ -110,7 +110,7 @@ func (s *EncryptionKeySetter) MutatePVC(ctx context.Context, pvc *corev1.Persist
 	// Skip mutation if the PVC is not provisioned by StorageOS
 	provisioned := provisioner.IsProvisionedStorageClass(storageClass, provisioner.DriverName)
 	if !provisioned {
-		log.V(4).Info("pvc does not provisioned by StorageOS, skipping")
+		log.V(4).Info("pvc will not be provisioned by StorageOS, skipping")
 		return nil
 	}
 
@@ -120,7 +120,7 @@ func (s *EncryptionKeySetter) MutatePVC(ctx context.Context, pvc *corev1.Persist
 	// Invalid value of encryption must block PVC creation.
 	enabled, err := s.isEnabled(pvc.GetLabels(), storageClass.Parameters)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to parse boolean value of %q pvc", s.enabledLabel))
+		return errors.Wrap(err, fmt.Sprintf("failed to parse %q option for PVC", s.enabledLabel))
 	}
 	if !enabled {
 		log.V(4).Info("pvc does not have encryption enabled, skipping")

--- a/controllers/pvc-mutator/encryption/keygen.go
+++ b/controllers/pvc-mutator/encryption/keygen.go
@@ -220,7 +220,7 @@ func GenerateVolumeSecretName() string {
 	return fmt.Sprintf("%s-%s", VolumeSecretNamePrefix, uuid.New().String())
 }
 
-// isEnabled iterates on the given maps and looks for encryption key. First occurrence wins
+// isEnabled iterates on the given maps and looks for encryption key. First occurrence wins.
 func (s *EncryptionKeySetter) isEnabled(hayStacks ...map[string]string) (bool, error) {
 	for _, hayStack := range hayStacks {
 		val, exists := hayStack[s.enabledLabel]


### PR DESCRIPTION
Original version checked encryption label only at the PVC, but encryption should be inherited from storage class. This change adds this ability.

The original encryption label parser forced un-encrypted storage creation if the label was invalid. This behavior leads to non encrypted volumes if user made a typo in label, which is not the safest way to handle the case. After this change invalid label value will block the PVC creation. 