### PR TITLE
Don't attempt service creation if the owning PVC doesn't exist

### DIFF
--- a/internal/controllers/sharedvolume/controller.go
+++ b/internal/controllers/sharedvolume/controller.go
@@ -167,11 +167,9 @@ func (r *Reconciler) Start(ctx context.Context) error {
 			// is no longer required and we can ignore the request.
 			pvc := &corev1.PersistentVolumeClaim{}
 			if err := r.Client.Get(ctx, types.NamespacedName{Name: vol.PVCName, Namespace: vol.Namespace}, pvc); err != nil {
-				if !apierrors.IsNotFound(err) {
-					observeErr(err, "failed to fetch pvc for shared volume")
-					span.End()
-					continue
-				}
+				observeErr(err, "failed to fetch pvc for shared volume")
+				span.End()
+				continue
 			}
 			ownerRef := metav1.OwnerReference{
 				APIVersion: "v1",


### PR DESCRIPTION
Fixes a log error where if the PVC wasn't found, the NFS service creation would still be attempted and fail since the OwnerReference UID would be empty.  Now it doesn't attempt the service creation until it can set the owner properly.

This removes a scary log message only - it doesn't change the behaviour.  For as long as the StorageOS volume is attached as RWX and there is no corresponding k8s service, the service creation will be retried.