### PR TITLE
Compare SC and PVC creation time during label sync

### DIFF
--- a/controllers/pvc-label/controller.go
+++ b/controllers/pvc-label/controller.go
@@ -81,7 +81,7 @@ func (c Controller) Ensure(ctx context.Context, obj client.Object) error {
 	// don't want to risk applying new default params automatically.  Instead,
 	// the user should manually remove the `storageos.com/storageclass=<uid>`
 	// annotation from the PVC to re-enable label sync for the volume.
-	ok, err := provisioner.ValidateOrSetStorageClassUID(ctx, c.Client, sc.UID, obj)
+	ok, err := provisioner.ValidateOrSetStorageClassUID(ctx, c.Client, sc, obj)
 	if err != nil {
 		return observeErr(fmt.Errorf("failed to set storageclass annotation on the pvc: %w", err))
 	}

--- a/controllers/pvc-label/controller.go
+++ b/controllers/pvc-label/controller.go
@@ -87,7 +87,7 @@ func (c Controller) Ensure(ctx context.Context, obj client.Object) error {
 	}
 	if !ok {
 		// Don't requeue if the StorageClass doesn't match, it's not transient.
-		c.log.Error(err, "current storageclass does not match storageclass annotation on the pvc, skipping label sync")
+		c.log.Error(err, "current storageclass does not match, skipping label sync")
 		return nil
 	}
 

--- a/internal/pkg/provisioner/storageclass.go
+++ b/internal/pkg/provisioner/storageclass.go
@@ -99,10 +99,11 @@ func StorageClassReservedParams(sc *storagev1.StorageClass) map[string]string {
 }
 
 // ValidateOrSetStorageClassUID returns true if the StorageClass annotation on
-// the PVC object matches the uid passed in or the StorageClass is younger than PVC.
+// the PVC object matches the UID of the passed in StorageClass
+// or the StorageClass has created before the given PVC.
 //
-// If the annotation does not exist and the StorageClass is younger than PVC,
-// it sets the uid passed in as the new StorageClass annotation.
+// If the annotation does not exist and the StorageClass has created before the PVC,
+// it sets the UID of the passed in StorageClass as the new StorageClass annotation.
 func ValidateOrSetStorageClassUID(ctx context.Context, k8s client.Client, sc client.Object, pvc client.Object) (bool, error) {
 	provisionedUID := pvc.GetAnnotations()[StorageClassUUIDAnnotationKey]
 	if provisionedUID != "" {
@@ -110,7 +111,7 @@ func ValidateOrSetStorageClassUID(ctx context.Context, k8s client.Client, sc cli
 		return string(sc.GetUID()) == provisionedUID, nil
 	}
 
-	// If StorageClass is younger than the PVC itself, the synchronization isn't safe.
+	// If StorageClass has created after the PVC itself, the synchronization isn't safe.
 	if sc.GetCreationTimestamp().Unix() > pvc.GetCreationTimestamp().Unix() {
 		return false, nil
 	}

--- a/internal/pkg/provisioner/storageclass.go
+++ b/internal/pkg/provisioner/storageclass.go
@@ -99,29 +99,33 @@ func StorageClassReservedParams(sc *storagev1.StorageClass) map[string]string {
 }
 
 // ValidateOrSetStorageClassUID returns true if the StorageClass annotation on
-// the PVC object matches the uid passed in.
+// the PVC object matches the uid passed in or the StorageClass is younger than PVC.
 //
-// If the annotation does not exist, it sets the uid passed in as the new
-// StorageClass annotation.
-func ValidateOrSetStorageClassUID(ctx context.Context, k8s client.Client, uid types.UID, obj client.Object) (bool, error) {
-	provisionedUID := obj.GetAnnotations()[StorageClassUUIDAnnotationKey]
+// If the annotation does not exist and the StorageClass is younger than PVC,
+// it sets the uid passed in as the new StorageClass annotation.
+func ValidateOrSetStorageClassUID(ctx context.Context, k8s client.Client, sc client.Object, pvc client.Object) (bool, error) {
+	provisionedUID := pvc.GetAnnotations()[StorageClassUUIDAnnotationKey]
 	if provisionedUID != "" {
-		return string(uid) == provisionedUID, nil
+		// If UID of StorageClass and PVC are different, the synchronization isn't safe.
+		return string(sc.GetUID()) == provisionedUID, nil
+	}
+
+	// If StorageClass is younger than the PVC itself, the synchronization isn't safe.
+	if sc.GetCreationTimestamp().Unix() > pvc.GetCreationTimestamp().Unix() {
+		return false, nil
+	}
+
+	// Convert client object to PersistentVolumeClaim.
+	var v1Pvc corev1.PersistentVolumeClaim
+	if err := k8s.Get(ctx, client.ObjectKeyFromObject(pvc), &v1Pvc); err != nil {
+		return false, err
 	}
 
 	// Annotation not set, set it.
-	if err := SetStorageClassUIDAnnotation(ctx, k8s, uid, obj); err != nil {
+	v1Pvc.Annotations[StorageClassUUIDAnnotationKey] = string(sc.GetUID())
+	if err := k8s.Update(ctx, &v1Pvc, &client.UpdateOptions{}); err != nil {
 		return false, err
 	}
-	return true, nil
-}
 
-// SetStorageClassUIDAnnotation adds the StorageClass annotation to a PVC object.
-func SetStorageClassUIDAnnotation(ctx context.Context, k8s client.Client, uid types.UID, obj client.Object) error {
-	var pvc corev1.PersistentVolumeClaim
-	if err := k8s.Get(ctx, client.ObjectKeyFromObject(obj), &pvc); err != nil {
-		return err
-	}
-	pvc.Annotations[StorageClassUUIDAnnotationKey] = string(uid)
-	return k8s.Update(ctx, &pvc, &client.UpdateOptions{})
+	return true, nil
 }


### PR DESCRIPTION
Currently if label sync finds the UID annotation it compares it to the current version of the StorageClass.
If it doesn't match, stop syncing the labels and some user action is needed.
If it isn't found it fetches the StorageClass and passes the parameters as labels.
In some edge cases we have the risk that we synchronize wrong parameters, because the parameters were different in the time of the PVC creation.
This change introduces usage of creation time to more safely use the underlying StorageClass, if SC is older, use it, if younger just stop syncing and ask the user to do some action.

