### PR TITLE
Leader election requires ability to patch events

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -30,3 +30,4 @@ rules:
   - events
   verbs:
   - create
+  - patch


### PR DESCRIPTION
Adding to rbac config - normally added by kubebuilder (fixed in 3.0.0)